### PR TITLE
Allow configuring max zoom and individual place zoom (#8, #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Copy the `/public/config.json` file into your content repository to `/content/se
 | search.result_card.title    | String  | Path to the value in the Typesense document that should be used as the card title. This value can contain nested objects (e.g. `<relationship-id>.0.name`).    |
 | search.result_card.subtitle | String  | Path to the value in the Typesense document that should be used as the card subtitle. This value can contain nested objects (e.g. `<relationship-id>.0.name`). |
 | search.timeline             | Boolean | If `true`, a timeline component will display in the search results based on the events within the project. Search results can be filtered by related events.   |
+| search.max_zoom             | Number  | The maximum zoom level to allow when the map view transitions to a set of bounds (a single place, or mulitple places).                                         |
+| search.zoom_to_place        | Boolean | If `true` or not specified, clicking on an individual place marker or search result will zoom the map to its location (using the max zoom).                    |
 | typesense                   | Object  | Typesense index connection information                                                                                                                         |
 | typesense.host              | String  | Typesense host URL                                                                                                                                             |
 | typesense.port              | Number  | Typesense host port                                                                                                                                            |

--- a/public/config.json
+++ b/public/config.json
@@ -20,7 +20,10 @@
     "cluster_radius": 6,
     "result_card": {
       "title": "name"
-    }
+    },
+    "timeline": false,
+    "zoom_to_place": false,
+    "max_zoom": 8
   },
   "typesense": {
     "host": "example.typesense.com",

--- a/public/config.json
+++ b/public/config.json
@@ -22,8 +22,8 @@
       "title": "name"
     },
     "timeline": false,
-    "zoom_to_place": false,
-    "max_zoom": 8
+    "zoom_to_place": true,
+    "max_zoom": 14
   },
   "typesense": {
     "host": "example.typesense.com",

--- a/src/apps/search/MapView.tsx
+++ b/src/apps/search/MapView.tsx
@@ -54,7 +54,7 @@ const MapView = () => {
       left: 380,
       right: 120
     },
-    maxZoom: 14
+    maxZoom: config.search.max_zoom || 14,
   }), []);
 
   /**

--- a/src/apps/search/Place.tsx
+++ b/src/apps/search/Place.tsx
@@ -14,7 +14,7 @@ import {
   usePlacesService,
 } from '@performant-software/core-data';
 import { LocationMarkers } from '@performant-software/geospatial';
-import { type AnnotationPage, useCurrentRoute, useNavigate } from '@peripleo/peripleo';
+import { type AnnotationPage, useCurrentRoute, useNavigate, useRuntimeConfig } from '@peripleo/peripleo';
 import { X } from 'lucide-react';
 import React, {
   useCallback,
@@ -32,6 +32,7 @@ type Place = {
 };
 
 const Place = () => {
+  const config = useRuntimeConfig<any>();
   const [place, setPlace] = useState<Place>();
 
   const [mediaLoading, setMediaLoading] = useState<boolean>(true);
@@ -59,7 +60,7 @@ const Place = () => {
       left: 380,
       right: 120,
     },
-    maxZoom: 14,
+    maxZoom: config.search.max_zoom || 14,
   };
 
   /**
@@ -132,6 +133,7 @@ const Place = () => {
         <LocationMarkers
           animate
           boundingBoxOptions={bboxOptions}
+          fitBoundingBox={Object.hasOwn(config.search, "zoom_to_place") ? config.search.zoom_to_place : true}
           data={placeData}
           layerId='current'
         />

--- a/src/apps/search/Place.tsx
+++ b/src/apps/search/Place.tsx
@@ -133,7 +133,7 @@ const Place = () => {
         <LocationMarkers
           animate
           boundingBoxOptions={bboxOptions}
-          fitBoundingBox={_.get(config.search, "zoom_to_place", true)}
+          fitBoundingBox={_.get(config.search, 'zoom_to_place', true)}
           data={placeData}
           layerId='current'
         />

--- a/src/apps/search/Place.tsx
+++ b/src/apps/search/Place.tsx
@@ -133,7 +133,7 @@ const Place = () => {
         <LocationMarkers
           animate
           boundingBoxOptions={bboxOptions}
-          fitBoundingBox={Object.hasOwn(config.search, "zoom_to_place") ? config.search.zoom_to_place : true}
+          fitBoundingBox={_.get(config.search, "zoom_to_place", true)}
           data={placeData}
           layerId='current'
         />


### PR DESCRIPTION
## In this PR

Per #8:
- Add a `search.zoom_to_place` boolean config option to allow disabling `fitBoundingBox` on the place detail page. In other words, allow users to disable zooming to an individual place on selection. Searches/filters narrowing the results will still zoom as before.

Per #9:
- Add a `search.max_zoom` numeric config option for adjusting the max zoom of the map.

## Notes

- Something I noticed while setting up my instance: the readme links to https://github.com/performant-software/core-data-tina-cms-content but that gives me a 404. Maybe it's a private repo? If it's been removed, we should update the readme.