### PR TITLE
Truncate search results to 3 lines of text (#10)

### DIFF
--- a/src/apps/search/SearchResultsList.tsx
+++ b/src/apps/search/SearchResultsList.tsx
@@ -60,7 +60,7 @@ const HitComponent = (props: HitComponentProps) => {
               <SearchHighlight
                 attribute={config.search.result_card.title}
                 badge
-                className='text-sm'
+                className='text-sm line-clamp-3 leading-6'
                 hit={hit}
               />
             )}


### PR DESCRIPTION
## In this PR

Per #10:
- A small CSS change that introduces `line-clamp-3` Tailwind class to search results, such that result text is clamped to three lines and does not overflow the element.
- Adds the `leading-6` class as somehow line-clamp clobbers the line height; this restores the line height to `1.5rem`.