### PR TITLE
Prevent key collision, resolve component duplication (#7)

### DIFF
--- a/src/apps/search/Place.tsx
+++ b/src/apps/search/Place.tsx
@@ -121,7 +121,7 @@ const Place = () => {
           />
         )}
         <RelatedRecords
-          key={uuid}
+          key={`related-${uuid}`}
           onLoadMedia={() => PlacesService.fetchRelatedManifests(uuid)}
           onLoadOrganizations={() => PlacesService.fetchRelatedOrganizations(uuid)}
           onLoadPeople={() => PlacesService.fetchRelatedPeople(uuid)}


### PR DESCRIPTION
## In this PR

Per #7:
- Fix a bug where place detail data would be appended rather than replaced, by preventing a key collision.

## Notes

Two adjacent components `PlaceDetails` and `RelatedRecords` shared a `key` attribute. For whatever reason, React decided that this meant it should append a new `PlaceDetails` whenever that key changed, while keeping the old one rendered. Resolving the collision also stopped this behavior.