### PR TITLE
Update search.max_zoom to map.max_zoom

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -17,11 +17,13 @@
     }
   ],
   "search": {
-    "cluster_radius": 6,
     "result_card": {
       "title": "name"
     },
-    "timeline": false,
+    "timeline": false
+  },
+  "map": {
+    "cluster_radius": 6,
     "zoom_to_place": true,
     "max_zoom": 14
   },

--- a/src/apps/search/panels/RecordPanel.tsx
+++ b/src/apps/search/panels/RecordPanel.tsx
@@ -40,7 +40,7 @@ const RecordPanel = (props: Props) => {
       left: 380,
       right: 120,
     },
-    maxZoom: config.search.max_zoom || 14,
+    maxZoom: config.map.max_zoom || 14,
   }), [config]);
 
   /**


### PR DESCRIPTION
## In this PR

Cleanup: code and example config still contained references to `search.max_zoom` when that property was changed to `map.max_zoom` in #43.