### PR TITLE
Adding custom primary colors and header logo

### DIFF
--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -22,7 +22,7 @@ const MobileHeader = (props: Props) => {
   return (
     <Disclosure 
       as='div' 
-      className='md:hidden w-full bg-white shadow-md z-10'
+      className='md:hidden w-full bg-primary shadow-md z-10'
     >
       {({ open }) => (
         <>
@@ -73,7 +73,7 @@ const MobileHeader = (props: Props) => {
             leaveTo='transform scale-95 opacity-0'
           >
             <Disclosure.Panel
-              className='md:hidden bg-white'
+              className='md:hidden bg-primary'
             >
               <div
                 className='space-y-1 pb-3 pt-2'
@@ -81,7 +81,7 @@ const MobileHeader = (props: Props) => {
                 { _.map(_.keys(props.tabs), (key) => (
                   <Disclosure.Button
                     as='a'
-                    className='block bg-white hover:bg-orange-primary/10 py-4 text-base text-center font-bold'
+                    className='block bg-primary hover:bg-white hover:text-black py-4 text-base text-center font-bold'
                     href={props.tabs[key].url}
                     key={key}
                   >

--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -44,7 +44,7 @@ const { title } = await fetchAbout();
               class='h-14'
               src={config.customization?.footer_logo}
             />
-            <h1 class='font-serif font-semibold text-[32px]'>
+            <h1 class='font-serif font-semibold text-[32px] text-center'>
               { title }
             </h1>
           ) : ( 
@@ -53,7 +53,7 @@ const { title } = await fetchAbout();
         }
       </div>
       <div
-        class='flex flex-col md:flex-row gap-x-12 align-baseline justify-around pt-4 pb-8'
+        class='flex flex-col md:flex-row gap-x-12 gap-y-4 items-center align-baseline justify-around pt-4 pb-8'
       >
         { _.map(_.keys(tabs), (key) => (
           <a

--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -2,90 +2,101 @@
 import { fetchAbout } from '@backend/tina-server';
 import Container from '@components/Container.astro';
 import config from '@config';
-import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import { Button } from '@performant-software/core-data';
+import _ from 'underscore';
 
-const { t } = Astro.props;
+const { t, tabs } = Astro.props;
 const { title } = await fetchAbout();
 ---
 
 <div
-  class='bg-white w-full'
+  class='bg-primary w-full'
 >
   <Container
-    className='flex flex-col gap-8 py-12 items-center'
+    className='flex flex-col py-12 items-center divide-y-2 divide-secondary'
   >
-    <div
-      class='flex flex-col md:flex-row gap-6 align-middle justify-center items-center'
-    >
+    {
+      config.customization?.footer_orgs && ( 
+        <div class='flex flex-row gap-12 justify-center flex-wrap py-8 w-full'>
+          { _.map(config.customization.footer_orgs, (org) => {
+            if (org.url) {
+              return (
+                <a href={org.url}>
+                  <img src={org.logo} alt={org.alt} class='h-24 object-contain' />
+                </a>
+              )
+            } else {
+              return (
+                <img src={org.logo} alt={org.alt} class='h-24 object-contain' />
+              )
+            }
+          })}
+        </div>
+      )
+    }
+    <div class='flex flex-col items-center w-full'>
       <div
-        class='w-20 h-20 rounded-full bg-blue-600'
-      />
-      <p
-        class='text-5xl font-serif self-center'
+        class='flex flex-col md:flex-row gap-6 align-middle justify-center items-center pt-8'
       >
-        { title }
-      </p>
-    </div>
-    <p
-      class='text-center'
-    >
-      { t('footerText') }
-    </p>
-    <div
-      class='flex flex-row justify-center gap-6 object-contain'
-    >
+        {
+          config.customization?.footer_title ? ( 
+            config.customization?.footer_logo && <img           
+              class='h-14'
+              src={config.customization?.footer_logo}
+            />
+            <h1 class='font-serif font-semibold text-[32px]'>
+              { title }
+            </h1>
+          ) : ( 
+            <img src={config.customization?.footer_logo} class='h-32' />
+          )
+        }
+      </div>
       <div
-        class='w-10 h-10 bg-blue-600 rounded-full'
-      />
-      <div
-        class='w-10 h-10 bg-blue-600 rounded-full'
-      />
-      <div
-        class='w-10 h-10 bg-blue-600 rounded-full'
-      />
-      <div
-        class='w-10 h-10 bg-blue-600 rounded-full'
-      />
-    </div>
-    <div
-      class='flex flex-row justify-center gap-8'
-    >
-      <a
-        href={config.core_data.url}
-        target='_blank'
+        class='flex flex-col md:flex-row gap-x-12 align-baseline justify-around pt-4 pb-8'
       >
-        <button
-          class='p-3 rounded-lg bg-blue-600 hover:bg-blue-800 text-white flex flex-row gap-3'
+        { _.map(_.keys(tabs), (key) => (
+          <a
+            class='flex flex-col p-y-4 justify-center'
+            href={tabs[key].url}
+          >
+            <div>
+              { t(key) }
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+    {
+      config.customization?.footer_login && (
+        <div
+          class='flex flex-row justify-center gap-8 py-8 w-full'
         >
-          <p>
-            { t('coreDataLogin') }
-          </p>
-          <ArrowTopRightOnSquareIcon
-            className='h-6 w-6'
-          />
-        </button>
-      </a>
-      <a
-        href='/admin/index.html'
-        target='_blank'
-      >
-        <button
-          class='p-3 rounded-lg bg-blue-600 hover:bg-blue-800 text-white flex flex-row gap-3'
-        >
-          <p>
-            { t('tinaLogin') }
-          </p>
-          <ArrowTopRightOnSquareIcon
-            className='h-6 w-6'
-          />
-        </button>
-      </a>
-    </div>
-    <div
-      class='h-[2px] bg-neutral-dark rounded-full w-full'
-    />
+          <a
+            href={config.core_data.url}
+            target='_blank'
+          >
+            <Button client:only rounded className='bg-white'>
+              <p>
+                { t('coreDataLogin') }
+              </p>
+            </Button>
+          </a>
+          <a
+            href='/admin/index.html'
+            target='_blank'
+          >
+            <Button client:only rounded className='bg-white'>
+              <p>
+                { t('tinaLogin') }
+              </p>
+            </Button>
+          </a>
+        </div>
+      )
+    }
     <p
-      class='text-center text-sm'
+      class='text-center text-sm py-8 w-full'
     >
       { t('footerCopyright') }
     </p>

--- a/src/layouts/Header.astro
+++ b/src/layouts/Header.astro
@@ -5,6 +5,7 @@ import MobileHeader from '@components/MobileHeader';
 import { getRelativeLocaleUrl, getRelativeLocaleUrlList } from 'astro:i18n';
 import clsx from 'clsx';
 import _ from 'underscore';
+import config from '@config';
 
 const locales = getRelativeLocaleUrlList();
 const currentLocale = Astro.currentLocale;
@@ -16,15 +17,23 @@ const { title } = await fetchAbout();
 ---
 
 <div
-  class='flex flex-row justify-between px-6 py-5 align-middle bg-primary text-white h-[80px]'
+  class='flex flex-row justify-between px-6 py-5 align-middle bg-primary h-[80px]'
 >
   <a
     class='flex flex-row align-middle gap-6'
     href={getRelativeLocaleUrl(currentLocale)}
   >
-    <h1>
-      { title }
-    </h1>
+    <!-- @ts-ignore -->
+    { config.customization?.header_logo && ( 
+      // @ts-ignore
+      <img src={config.customization.header_logo} alt={title} class="h-10" />
+    )}
+    <!-- @ts-ignore -->
+    { config.customization?.header_title && ( 
+      <h1>
+        { title }
+      </h1>
+    )}
   </a>
   <div
     class='flex flex-row gap-x-12 pe-10 align-baseline justify-around'

--- a/src/layouts/Header.astro
+++ b/src/layouts/Header.astro
@@ -11,62 +11,64 @@ const locales = getRelativeLocaleUrlList();
 const currentLocale = Astro.currentLocale;
 const currentUrl = Astro.url;
 
-const { currentTab, t, tabs } = Astro.props;
+const { currentTab, t, tabs, fullscreen } = Astro.props;
 
 const { title } = await fetchAbout();
 ---
 
-<div
-  class='flex flex-row justify-between px-6 py-5 align-middle bg-primary h-[80px]'
->
-  <a
-    class='flex flex-row align-middle gap-6'
-    href={getRelativeLocaleUrl(currentLocale)}
-  >
-    <!-- @ts-ignore -->
-    { config.customization?.header_logo && ( 
-      // @ts-ignore
-      <img src={config.customization.header_logo} alt={title} class="h-10" />
-    )}
-    <!-- @ts-ignore -->
-    { config.customization?.header_title && ( 
-      <h1>
-        { title }
-      </h1>
-    )}
-  </a>
+<div class='bg-primary flex flex-row justify-center w-full'>
   <div
-    class='flex flex-row gap-x-12 pe-10 align-baseline justify-around'
+    class={clsx('hidden md:flex flex-row justify-between px-6 py-5 align-middle bg-primary h-[80px] w-full', {'3xl:max-w-screen-3xl': !fullscreen})}
   >
-    { _.map(_.keys(tabs), (key) => (
-      <a
-        class='flex flex-col p-y-4 justify-center'
-        href={tabs[key].url}
-      >
-        <div
-          class={clsx(
-            'flex',
-            'font-light',
-            { 'border-b': key === currentTab }
-          )}
+    <a
+      class='flex flex-row align-middle gap-6'
+      href={getRelativeLocaleUrl(currentLocale)}
+    >
+      <!-- @ts-ignore -->
+      { config.customization?.header_logo && ( 
+        // @ts-ignore
+        <img src={config.customization.header_logo} alt={title} class="h-10" />
+      )}
+      <!-- @ts-ignore -->
+      { config.customization?.header_title && ( 
+        <h1>
+          { title }
+        </h1>
+      )}
+    </a>
+    <div
+      class='flex flex-row gap-x-12 pe-10 align-baseline justify-around'
+    >
+      { _.map(_.keys(tabs), (key) => (
+        <a
+          class='flex flex-col p-y-4 justify-center'
+          href={tabs[key].url}
         >
-          { t(key) }
-        </div>
-      </a>
-    ))}
-    <LanguagePicker
-      locales={locales}
-      currentLocale={currentLocale}
-      currentUrl={currentUrl.pathname}
-      client:only='react'
-    />
+          <div
+            class={clsx(
+              'flex',
+              'font-light',
+              { 'border-b': key === currentTab }
+            )}
+          >
+            { t(key) }
+          </div>
+        </a>
+      ))}
+      <LanguagePicker
+        locales={locales}
+        currentLocale={currentLocale}
+        currentUrl={currentUrl.pathname}
+        client:only='react'
+      />
+    </div>
   </div>
+  
+  <MobileHeader
+    currentLocale={Astro.currentLocale}
+    currentUrl={currentUrl.pathname}
+    locales={locales}
+    tabs={tabs}
+    client:load
+  />
 </div>
-
-<MobileHeader
-  currentLocale={Astro.currentLocale}
-  currentUrl={currentUrl.pathname}
-  locales={locales}
-  tabs={tabs}
-  client:load
-/>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,7 +13,7 @@ import clsx from 'clsx';
 import _ from 'underscore';
 import { useBlackText } from '@utils/layout';
 
-const primaryText = config.customization?.primary && useBlackText(config.customization.primary) ? 'black' : 'white';
+const blackText = config.customization?.primary && useBlackText(config.customization.primary);
 
 const currentLocale = Astro.currentLocale;
 const lang = getLanguageFromUrl(Astro.url.pathname);
@@ -60,8 +60,8 @@ const tabs = {
   <body
     class={clsx(
       'flex h-full sm:min-h-screen flex-col bg-white text-neutral-dark mx-auto',
-      `primary-text-${primaryText}`,
-      { '3xl:bg-neutral-dark 3xl:max-w-screen-3xl': !fullscreen }
+      { 'primary-text-white': !blackText },
+      { 'primary-text-black': blackText },
     )}
     transition:animate='initial'
   >

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -79,6 +79,7 @@ const tabs = {
     { footer && (
       <Footer
         t={t}
+        tabs={tabs}
       />
     )}
   </body>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,6 +11,9 @@ import '@styles/index.css';
 import { getRelativeLocaleUrl } from 'astro:i18n';
 import clsx from 'clsx';
 import _ from 'underscore';
+import { useBlackText } from '@utils/layout';
+
+const primaryText = config.customization?.primary && useBlackText(config.customization.primary) ? 'black' : 'white';
 
 const currentLocale = Astro.currentLocale;
 const lang = getLanguageFromUrl(Astro.url.pathname);
@@ -57,6 +60,7 @@ const tabs = {
   <body
     class={clsx(
       'flex h-full sm:min-h-screen flex-col bg-white text-neutral-dark mx-auto',
+      `primary-text-${primaryText}`,
       { '3xl:bg-neutral-dark 3xl:max-w-screen-3xl': !fullscreen }
     )}
     transition:animate='initial'

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -62,3 +62,13 @@ html, body {
 .p6o-controls-container {
   overflow: hidden;
 }
+
+.primary-text-white .bg-primary, .primary-text-white .fill-primary, .primary-text-white .bg-primary div {
+  color: white;
+  border-color: white;
+}
+
+.primary-text-black .bg-primary, .primary-text-black .fill-primary, .primary-text-black .bg-primary div {
+  color: black;
+  border-color: black;
+}

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,0 +1,16 @@
+export const useBlackText = (primary: string) => {
+    if (primary.length !== 7) {
+        return false;
+    }
+    const r_ratio = parseInt(primary.slice(1,3), 16)/255.0;
+    const g_ratio = parseInt(primary.slice(3,5), 16)/255.0;
+    const b_ratio = parseInt(primary.slice(5,7), 16)/255.0;
+    const r = r_ratio <= 0.04045 ? r_ratio/12.92 : ((r_ratio + 0.055)/1.055)**2.4;
+    const g = g_ratio <= 0.04045 ? g_ratio/12.92 : ((g_ratio + 0.055)/1.055)**2.4;
+    const b = b_ratio <= 0.04045 ? b_ratio/12.92 : ((b_ratio + 0.055)/1.055)**2.4;
+    const l = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    if (l > 0.179) {
+      return true;
+    }
+    return false;
+}

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,3 +1,11 @@
+/**
+ * 
+ * @param primary a color in hex format
+ * @returns true if black text should be used on a background of color primary for contrast, false otherwise
+ * 
+ * (source for formula: https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color)
+ */
+
 export const useBlackText = (primary: string) => {
     if (primary.length !== 7) {
         return false;

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -17,8 +17,5 @@ export const useBlackText = (primary: string) => {
     const g = g_ratio <= 0.04045 ? g_ratio/12.92 : ((g_ratio + 0.055)/1.055)**2.4;
     const b = b_ratio <= 0.04045 ? b_ratio/12.92 : ((b_ratio + 0.055)/1.055)**2.4;
     const l = 0.2126 * r + 0.7152 * g + 0.0722 * b;
-    if (l > 0.179) {
-      return true;
-    }
-    return false;
+    return l > 0.179;
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 import coreDataConfig from '@performant-software/core-data/tailwind.config';
 import typeography from '@tailwindcss/typography';
+import config from './public/config.json';
 
 export default {
 	presets: [
@@ -19,6 +20,7 @@ export default {
 				'screen-3xl': '1800px',
 			},
 			colors: {
+				primary: config.customization.primary || coreDataConfig.theme.extend.colors.primary,
 				'neutral-dark': '#111928',
 				'neutral-light': '#F5F5F5',
 				gray: {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -20,7 +20,7 @@ export default {
 				'screen-3xl': '1800px',
 			},
 			colors: {
-				primary: config.customization.primary || coreDataConfig.theme.extend.colors.primary,
+				primary: config.customization?.primary || coreDataConfig.theme.extend.colors.primary,
 				'neutral-dark': '#111928',
 				'neutral-light': '#F5F5F5',
 				gray: {

--- a/tina/content/settings.ts
+++ b/tina/content/settings.ts
@@ -207,7 +207,9 @@ const Settings: Collection = {
     type: 'object',
     defaultItem: () => ({
       'primary': '#073B4C',
-      'header_title': true
+      'header_title': true,
+      'footer_title': true,
+      'footer_login': true
     }),
     fields: [{     
       type: 'string',
@@ -227,8 +229,40 @@ const Settings: Collection = {
     }, {
       type: 'boolean',
       name: 'header_title',
-      label: 'Display Title Text?',
+      label: 'Header - Display Title Text?',
       description: 'If checked, will display your project\'s title in the header along with the logo (if provided).'
+    }, {
+      type: 'image',
+      name: 'footer_logo',
+      label: 'Footer Logo'
+    }, {
+      type: 'boolean',
+      name: 'footer_title',
+      label: 'Footer - Display Title Text?',
+      description: 'If checked, will display your project\'s title in the footer along with the logo (if provided).'
+    }, {
+      type: 'object',
+      name: 'footer_orgs',
+      label: 'Footer Organizations',
+      description: 'List of logos to display in the footer, e.g. partners or sponsors',
+      list: true,
+      fields: [{
+        type: 'image',
+        name: 'logo',
+        label: 'Logo/Image'
+      }, {
+        type: 'string',
+        name: 'url',
+        label: 'Link'
+      }, {
+        type: 'string',
+        name: 'alt',
+        label: 'Image alt text'
+      }]
+    }, {
+      type: 'boolean',
+      name: 'footer_login',
+      label: 'Display Core Data and CMS login buttons in footer?'
     }]
   }],
   ui: {

--- a/tina/content/settings.ts
+++ b/tina/content/settings.ts
@@ -201,6 +201,35 @@ const Settings: Collection = {
       type: 'string',
       list: true
     }]
+  }, {
+    name: 'customization',
+    label: 'Customization and Branding',
+    type: 'object',
+    defaultItem: () => ({
+      'primary': '#073B4C',
+      'header_title': true
+    }),
+    fields: [{     
+      type: 'string',
+      name: 'primary',
+      label: 'Primary Color',
+      ui: {
+        component: 'color',
+        //@ts-ignore
+        colorFormat: 'hex',
+        colors: ['#073B4C'],
+        widget: 'sketch',
+      }
+    }, {
+      type: 'image',
+      name: 'header_logo',
+      label: 'Header Logo'
+    }, {
+      type: 'boolean',
+      name: 'header_title',
+      label: 'Display Title Text?',
+      description: 'If checked, will display your project\'s title in the header along with the logo (if provided).'
+    }]
   }],
   ui: {
     allowedActions: {


### PR DESCRIPTION
### In this PR
First pass at adding the ability to customize the primary color and add a logo to the header, as well as updating the footer to the new designs and allowing logos to be added to it.

### Notes and questions
For the time being after struggling a bunch to figure out how to set Tailwind colors using asynchronously fetched data, I ended up putting the customization fields in the `settings` collection rather than the `about` collection, so that they end up in the `config.json` file that's already being copied to the `public` folder at build time. This seems to work, but if we'd prefer those fields to be in the `about` collection, then it could probably be done with an additional build script that runs before `astro build` and copies the color info to somewhere Tailwind can find it. I currently don't think there's an easy way around having to rebuild the site if the primary color is changed.

I wasn't sure exactly how much customization we need to build into the footer, so for now I kept it pretty minimal, but of course more toggles can be added for like, should the background be primary or white, or whatever.

### Screenshots

With custom (light) primary color: 
![image](https://github.com/user-attachments/assets/3e9a0ede-f971-44e0-86d6-77f4361f0c3a)

New category in `Settings` collection in Tina: 
![image](https://github.com/user-attachments/assets/6bf75f87-2033-41ae-9f43-4bace891cbd5)

Adding primary color: 
![image](https://github.com/user-attachments/assets/1d371fd7-b64a-44fb-b773-baf91b75121d)

All settings: 
![image](https://github.com/user-attachments/assets/04fc19c6-bacb-4f4a-9c12-022ee63335ab)
