### PR TITLE
Adding i18n functionality to `about` collection

### DIFF
--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -53,10 +53,26 @@ export const buildTranslations = (data: TranslationData) => {
   return _.defaults(translations, defaultTranslations);
 };
 
-export const getLocalizedContent = (data: any, attributes: string[], lang: string, isDefault: boolean) => {
-  let localizedContent: any = {};
-  for (const att of attributes) {
-    localizedContent[att] = isDefault || !data[lang][att] ? data[att] : data[lang][att];
+export const isEmptyRichText = (content: any) => {
+  if (!(typeof content == 'object')) {
+    return false;
   }
-  return localizedContent;
+  if (Object.keys(content).includes('children') && (!content.children || !content.children.length)) {
+    return true;
+  }
+  return false;
+}
+
+export const getLocalizedContent = (data: any, lang?: string) => {
+  if (!lang || !data[lang]) {
+    return data;
+  }
+  let localizedContent: any = {};
+  for (const att of Object.keys(data[lang])) {
+    localizedContent[att] = data[lang][att] && !isEmptyRichText(data[lang][att]) ? data[lang][att] : data[att];
+  }
+  return ({
+    ...data,
+    ...localizedContent
+  });
 };

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -52,3 +52,11 @@ export const buildTranslations = (data: TranslationData) => {
 
   return _.defaults(translations, defaultTranslations);
 };
+
+export const getLocalizedContent = (data: any, attributes: string[], lang: string, isDefault: boolean) => {
+  let localizedContent: any = {};
+  for (const att of attributes) {
+    localizedContent[att] = isDefault || !data[lang][att] ? data[att] : data[lang][att];
+  }
+  return localizedContent;
+};

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -63,8 +63,8 @@ export const isEmptyRichText = (content: any) => {
   return false;
 }
 
-export const getLocalizedContent = (data: any, lang?: string) => {
-  if (!lang || !data[lang]) {
+export const getLocalizedContent = (data: any, lang: string) => {
+  if (!data[lang]) {
     return data;
   }
   let localizedContent: any = {};

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -8,7 +8,14 @@ import Layout from '@layouts/Layout.astro';
 import { TinaMarkdown } from 'tinacms/dist/rich-text';
 import _ from 'underscore';
 
-const { title, subheader, description, heroImage, featureImage } = await fetchAbout();
+const aboutResponse = await fetchAbout();
+const { heroImage, featureImage } = aboutResponse;
+
+// Get localized content, defaulting to the default language if not defined
+const { title } = Astro.currentLocale == config.i18n.default_locale || !aboutResponse[Astro.currentLocale]?.title ? aboutResponse : aboutResponse[Astro.currentLocale];
+const { subheader } = Astro.currentLocale == config.i18n.default_locale || !aboutResponse[Astro.currentLocale]?.subheader ? aboutResponse : aboutResponse[Astro.currentLocale];
+const { description } = Astro.currentLocale == config.i18n.default_locale || !aboutResponse[Astro.currentLocale]?.description ? aboutResponse : aboutResponse[Astro.currentLocale];
+
 const { t } = await getTranslations(Astro.currentLocale);
 
 export const getStaticPaths = () => _.map(config.i18n.locales, (lang) => ({ params: { lang }}));

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -15,7 +15,7 @@ const { heroImage, featureImage } = aboutResponse;
 console.log(typeof aboutResponse.description);
 
 // Get localized content, defaulting to the default language if not defined
-const { title, subheader, description } = getLocalizedContent(aboutResponse, Astro.currentLocale !== config.i18n.default_locale && Astro.currentLocale);
+const { title, subheader, description } = getLocalizedContent(aboutResponse, Astro.currentLocale);
 
 const { t } = await getTranslations(Astro.currentLocale);
 

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -12,8 +12,10 @@ import { getLocalizedContent } from '@i18n/utils';
 const aboutResponse = await fetchAbout();
 const { heroImage, featureImage } = aboutResponse;
 
+console.log(typeof aboutResponse.description);
+
 // Get localized content, defaulting to the default language if not defined
-const { title, subheader, description } = getLocalizedContent(aboutResponse, ['title', 'subheader', 'description'], Astro.currentLocale, Astro.currentLocale == config.i18n.default_locale);
+const { title, subheader, description } = getLocalizedContent(aboutResponse, Astro.currentLocale !== config.i18n.default_locale && Astro.currentLocale);
 
 const { t } = await getTranslations(Astro.currentLocale);
 

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -7,14 +7,13 @@ import { getTranslations } from '@i18n/server';
 import Layout from '@layouts/Layout.astro';
 import { TinaMarkdown } from 'tinacms/dist/rich-text';
 import _ from 'underscore';
+import { getLocalizedContent } from '@i18n/utils';
 
 const aboutResponse = await fetchAbout();
 const { heroImage, featureImage } = aboutResponse;
 
 // Get localized content, defaulting to the default language if not defined
-const { title } = Astro.currentLocale == config.i18n.default_locale || !aboutResponse[Astro.currentLocale]?.title ? aboutResponse : aboutResponse[Astro.currentLocale];
-const { subheader } = Astro.currentLocale == config.i18n.default_locale || !aboutResponse[Astro.currentLocale]?.subheader ? aboutResponse : aboutResponse[Astro.currentLocale];
-const { description } = Astro.currentLocale == config.i18n.default_locale || !aboutResponse[Astro.currentLocale]?.description ? aboutResponse : aboutResponse[Astro.currentLocale];
+const { title, subheader, description } = getLocalizedContent(aboutResponse, ['title', 'subheader', 'description'], Astro.currentLocale, Astro.currentLocale == config.i18n.default_locale);
 
 const { t } = await getTranslations(Astro.currentLocale);
 

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -12,8 +12,6 @@ import { getLocalizedContent } from '@i18n/utils';
 const aboutResponse = await fetchAbout();
 const { heroImage, featureImage } = aboutResponse;
 
-console.log(typeof aboutResponse.description);
-
 // Get localized content, defaulting to the default language if not defined
 const { title, subheader, description } = getLocalizedContent(aboutResponse, Astro.currentLocale);
 

--- a/tina/content/about.ts
+++ b/tina/content/about.ts
@@ -23,7 +23,7 @@ const textFields = (isBody: boolean): TinaField<false>[] => ([{
 
 const localeFields: TinaField<false>[] = _.map(_.filter(config.i18n.locales, (lang) => (lang !== config.i18n.default_locale)), (lang) => ({
   name: lang,
-  label: lang,
+  label: lang.toUpperCase(),
   type: 'object',
   fields: textFields(false)
 }));

--- a/tina/content/about.ts
+++ b/tina/content/about.ts
@@ -1,4 +1,32 @@
 import { Collection } from '@tinacms/schema-tools';
+import config from '@config';
+import { TinaField } from 'tinacms';
+import _ from 'underscore';
+
+const textFields = (isBody: boolean): TinaField<false>[] => ([{
+  type: 'string',
+  name: 'title',
+  label: 'Project Title',
+}, {
+  type: 'string',
+  name: 'subheader',
+  label: 'Subheader',
+  ui: {
+    component: 'textarea'
+  }
+}, {
+  type: 'rich-text',
+  name: 'description',
+  label: 'Project Description',
+  isBody: isBody
+}]);
+
+const localeFields: TinaField<false>[] = _.map(_.filter(config.i18n.locales, (lang) => (lang !== config.i18n.default_locale)), (lang) => ({
+  name: lang,
+  label: lang,
+  type: 'object',
+  fields: textFields(false)
+}));
 
 const About: Collection = {
   name: 'about',
@@ -6,25 +34,8 @@ const About: Collection = {
   path: 'content/about',
   format: 'mdx',
   fields: [
-    {
-      type: 'string',
-      name: 'title',
-      label: 'Project Title',
-    },
-    {
-      type: 'string',
-      name: 'subheader',
-      label: 'Subheader',
-      ui: {
-        component: 'textarea'
-      }
-    },
-    {
-      type: 'rich-text',
-      name: 'description',
-      label: 'Project Description',
-      isBody: true
-    },
+    ...textFields(true),
+    ...localeFields,
     {
       type: 'image',
       name: 'heroImage',


### PR DESCRIPTION
### In this PR
- Updates the schema of the `about` collection in TinaCMS to allow users to add `title`, `subheader`, and `description` for each language specified in the `config.json` file, with the default locale as top level fields and other locales as nested fields (this allows compatibility with how existing project content is configured with only one language);
- Updates the `pages/[lang]/index.astro` to fetch localized text content, and default to the default locale if no localized content is defined.

### Screenshots
![image](https://github.com/user-attachments/assets/7e049583-6055-4228-91fa-f1a6e9799237)
![image](https://github.com/user-attachments/assets/4f3158b0-ec17-4481-abe5-e7b8f28c70f7)
