### PR TITLE
Suppress modal when clicking on zoom controls

### DIFF
--- a/src/components/PlacesMap.tsx
+++ b/src/components/PlacesMap.tsx
@@ -57,22 +57,24 @@ const PlacesMap = (props: Props) => {
       <Map
         style={PeripleoUtils.toLayerStyle(baseLayer, baseLayer.name)}
       >
-        <Controls
-          position='topright'
-        >
-          <Zoom />
-          { baseLayers.length > 1 && (
-            <LayerMenu
-              baseLayer={baseLayer?.name}
-              baseLayers={baseLayers}
-              baseLayersLabel={'Base Layers'}
-              dataLayers={dataLayers}
-              onChangeBaseLayer={setBaseLayer}
-              onChangeOverlays={setOverlays}
-              overlaysLabel={'Overlays'}
-            />
-          )}
-        </Controls>
+        <div onClick={(e: any) => { e.stopPropagation(); }}>
+          <Controls
+            position='topright'
+          >
+            <Zoom />
+            { baseLayers.length > 1 && (
+              <LayerMenu
+                baseLayer={baseLayer?.name}
+                baseLayers={baseLayers}
+                baseLayersLabel={'Base Layers'}
+                dataLayers={dataLayers}
+                onChangeBaseLayer={setBaseLayer}
+                onChangeOverlays={setOverlays}
+                overlaysLabel={'Overlays'}
+              />
+            )}
+          </Controls>
+        </div>
         <OverlayLayers
           overlays={overlays}
           key={`overlay-${props.mapId}`}


### PR DESCRIPTION
### In this PR
Fixes the behavior described in Issue #92 by stopping propagation when clicking on the controls of an embedded map (e.g. in a post), so that the place modal does not open.