### PR TITLE
Use `result_card.attributes` array for `ResultTooltip` text

### DIFF
--- a/src/apps/search/ResultTooltip.tsx
+++ b/src/apps/search/ResultTooltip.tsx
@@ -62,9 +62,9 @@ const ResultTooltip = (props: Props) => {
           hit={hit}
         />
       )}
-      { !isCluster && config.search.result_card.subtitle && (
+      { !isCluster && config.search.result_card.attributes && config.search.result_card.attributes.length > 0 && (
         <SearchHighlight
-          attribute={config.search.result_card.subtitle}
+          attribute={config.search.result_card.attributes[0].name}
           className='truncate'
           badge={!isCluster}
           hit={hit}


### PR DESCRIPTION
# Summary

This PR changes the source of the text in the `ResultTooltip` from `result_card.subtitle` to the first entry in `result_card.attributes`. If the `attributes` array is empty or doesn't exist, only the `title` value will be shown.