### PR TITLE
CDP #102 - Layout

### DIFF
--- a/src/apps/search/ClearRefinementsButton.tsx
+++ b/src/apps/search/ClearRefinementsButton.tsx
@@ -1,11 +1,17 @@
 import TranslationContext from '@apps/search/TranslationContext';
 import { Icon } from '@performant-software/core-data';
 import { useContext } from 'react';
-import { useClearRefinements } from 'react-instantsearch';
+import { useClearRefinements, useCurrentRefinements } from 'react-instantsearch';
+import _ from 'underscore';
 
 const ClearRefinementsButton = () => {
   const { refine } = useClearRefinements();
+  const { items } = useCurrentRefinements();
   const { t } = useContext(TranslationContext);
+
+  if (_.isEmpty(items)) {
+    return null;
+  }
 
   return (
     <button

--- a/src/apps/search/Header.tsx
+++ b/src/apps/search/Header.tsx
@@ -91,6 +91,7 @@ const Header = (props: Props) => {
           rounded
         >
           <Button
+            className='text-smd'
             primary={props.view === Views.list}
             onClick={() => props.onViewChange(Views.list)}
           >
@@ -100,6 +101,7 @@ const Header = (props: Props) => {
             { t('list') }
           </Button>
           <Button
+            className='text-smd'
             primary={props.view === Views.table}
             onClick={() => props.onViewChange(Views.table)}
           >

--- a/src/apps/search/Header.tsx
+++ b/src/apps/search/Header.tsx
@@ -70,7 +70,7 @@ const Header = (props: Props) => {
             )}
           </Button>
           <h2
-            className='text-xl font-semibold text-nowrap px-3'
+            className='text-xl font-bold text-nowrap px-3'
           >
             { t('root') }
           </h2>

--- a/src/apps/search/Header.tsx
+++ b/src/apps/search/Header.tsx
@@ -33,7 +33,7 @@ const Header = (props: Props) => {
       className={clsx('bg-neutral-100 flex items-center justify-between px-6 py-5 shadow', props.className)}
     >
       <div
-        className='flex items-center gap-x-10 w-3/4'
+        className='flex items-center gap-x-12 w-3/4'
       >
         <div
           className='flex items-center'

--- a/src/apps/search/ListView.tsx
+++ b/src/apps/search/ListView.tsx
@@ -1,5 +1,6 @@
 import SearchHighlight from '@apps/search/SearchHighlight';
 import useHoverable from '@apps/search/useHoverable';
+import useSelectable from '@apps/search/useSelectable';
 import { SearchList, useCachedHits } from '@performant-software/core-data';
 import { useNavigate, useRuntimeConfig } from '@peripleo/peripleo';
 import { renderFlattenedAttribute } from '@root/src/utils/search';
@@ -16,6 +17,7 @@ const ListView = (props: Props) => {
   const navigate = useNavigate();
 
   const { isHover, onPointEnter, onPointLeave } = useHoverable();
+  const { isSelected } = useSelectable();
 
   /**
    * List of attributes to display in the search list
@@ -67,7 +69,7 @@ const ListView = (props: Props) => {
       <SearchList
         attributes={attributes}
         className='flex flex-col'
-        isHighlight={isHover}
+        isHighlight={(item) => isHover(item) || isSelected(item)}
         items={hits}
         itemTitle={renderItemTitle}
         onItemClick={onRowClick}

--- a/src/apps/search/SearchLayout.tsx
+++ b/src/apps/search/SearchLayout.tsx
@@ -12,7 +12,7 @@ import { useMemo, useState } from 'react';
 
 const DEFAULT_MAX_ZOOM = 14;
 
-const DEFAULT_PADDING_TOP = 100;
+const DEFAULT_PADDING_TOP = 80;
 const DEFAULT_PADDING_BOTTOM = 100;
 const DEFAULT_PADDING_LEFT = 120;
 const DEFAULT_PADDING_RIGHT = 120;
@@ -70,12 +70,12 @@ const SearchLayout = () => {
       }}
     >
       <div
-        className='absolute left-0 right-0 bottom-0 top-[80px]'
+        className='absolute left-0 right-0 bottom-0 top-[64px]'
       >
         <MapView />
       </div>
       <Header
-        className='h-[80px]'
+        className='h-[64px]'
         filters={filters}
         onFiltersChange={setFilters}
         onViewChange={setView}

--- a/src/apps/search/TableView.tsx
+++ b/src/apps/search/TableView.tsx
@@ -1,6 +1,7 @@
 import SearchHighlight from '@apps/search/SearchHighlight';
 import TranslationContext from '@apps/search/TranslationContext';
 import useHoverable from '@apps/search/useHoverable';
+import useSelectable from '@apps/search/useSelectable';
 import { SearchResultsTable, useCachedHits } from '@performant-software/core-data';
 import { useNavigate, useRuntimeConfig } from '@peripleo/peripleo';
 import { getColumnLabel, renderFlattenedAttribute } from '@root/src/utils/search';
@@ -15,10 +16,11 @@ interface Props {
 const TableView = (props: Props) => {
   const config = useRuntimeConfig<any>();
   const hits = useCachedHits();
+  const navigate = useNavigate();
   const { t } = useContext(TranslationContext);
 
   const { isHover, onPointEnter, onPointLeave } = useHoverable();
-  const navigate = useNavigate();
+  const { isSelected } = useSelectable();
 
   const { title } = config.search.result_card;
 
@@ -71,7 +73,7 @@ const TableView = (props: Props) => {
             />
           )
         }, ...columns]}
-        isHighlight={isHover}
+        isHighlight={(item) => isHover(item) || isSelected(item)}
         onRowClick={onRowClick}
         onRowPointerEnter={onPointEnter}
         onRowPointerLeave={onPointLeave}

--- a/src/apps/search/useSelectable.ts
+++ b/src/apps/search/useSelectable.ts
@@ -1,0 +1,16 @@
+import { useCurrentRoute } from '@peripleo/peripleo';
+import { getCurrentId } from '@utils/router';
+import { useCallback } from 'react';
+
+const useSelectable = () => {
+  const route = useCurrentRoute();
+  const id = getCurrentId(route);
+
+  const isSelected = useCallback((hit) => hit.id === id, [id]);
+
+  return {
+    isSelected
+  };
+};
+
+export default useSelectable;

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -13,12 +13,6 @@ export default {
 	],
 	theme: {
 		extend: {
-			screens: {
-				'3xl': '1800px',
-			},
-			maxWidth: {
-				'screen-3xl': '1800px',
-			},
 			colors: {
 				primary: config.branding?.primary || coreDataConfig.theme.extend.colors.primary,
 				'neutral-dark': '#111928',
@@ -26,6 +20,15 @@ export default {
 				gray: {
 					1000: '#505A6A'
 				},
+			},
+			fontSize: {
+				'smd': '0.938rem'
+			},
+			maxWidth: {
+				'screen-3xl': '1800px',
+			},
+			screens: {
+				'3xl': '1800px',
 			}
 		}
 	},


### PR DESCRIPTION
This pull request addresses the feedback in #102 by making the following changes:

## Search Header
- Updates the search header bar height from 80px to 64px
- Adjusts the spacing between title and search input to `gap-x-12`
- Updates "List" and "Table" buttons to use `text-smd` font size (15px equivalent with 16px base)
- Updates title to `font-bold`

![Screenshot 2025-03-04 at 6 52 21 AM](https://github.com/user-attachments/assets/7811e698-56e5-49da-93f2-c757dac81034)

## Facets Clear
Hides the "Reset" facets button until filters have been applied

![Screenshot 2025-03-04 at 6 53 38 AM](https://github.com/user-attachments/assets/508ab00b-d159-468f-ad99-cac6ea15c770)
![Screenshot 2025-03-04 at 6 53 43 AM](https://github.com/user-attachments/assets/cd6d04f0-6d86-4860-9773-848281fb589b)

## Selection State
Updates the ListView and TableView to highlight selected records when detail panel is open

![Screenshot 2025-03-04 at 6 55 24 AM](https://github.com/user-attachments/assets/1c5ac0e8-a570-406f-853e-505391404617)
![Screenshot 2025-03-04 at 6 55 30 AM](https://github.com/user-attachments/assets/c0ad4c09-72e8-4f71-9f5e-3370da30c3d6)
