### PR TITLE
CDP #95 - Map controls

### DIFF
--- a/src/apps/search/MapView.tsx
+++ b/src/apps/search/MapView.tsx
@@ -10,13 +10,13 @@ import {
 } from '@performant-software/core-data';
 import { Map, Tooltip, Zoom } from '@peripleo/maplibre';
 import {
-  Controls,
   useCurrentRoute,
   useNavigate,
   useRuntimeConfig,
   useSelectionValue
 } from '@peripleo/peripleo';
 import { parseFeature } from '@utils/search';
+import clsx from 'clsx';
 import {
   useContext,
   useEffect,
@@ -46,7 +46,7 @@ const MapView = () => {
   const selected = useSelectionValue<any>();
   const route = useCurrentRoute();
 
-  const { boundingBoxOptions } = useContext(SearchContext);
+  const { boundingBoxOptions, controlsClass } = useContext(SearchContext);
   const { t } = useContext(TranslationContext);
 
   /**
@@ -77,8 +77,12 @@ const MapView = () => {
       className='flex-grow'
       style={PeripleoUtils.toLayerStyle(baseLayer, baseLayer.name)}
     >
-      <Controls
-        position='topright'
+      <div
+        className={clsx(
+          'p6o-controls-container',
+          'topright',
+          controlsClass
+        )}
       >
         <Zoom />
         { [...baseLayers, ...dataLayers].length > 1 && (
@@ -92,7 +96,7 @@ const MapView = () => {
             overlaysLabel={t('overlays')}
           />
         )}
-      </Controls>
+      </div>
       <OverlayLayers
         overlays={overlays}
       />

--- a/src/apps/search/SearchContext.tsx
+++ b/src/apps/search/SearchContext.tsx
@@ -10,6 +10,7 @@ interface SearchContextType {
     },
     maxZoom: number
   };
+  controlsClass?: string;
 }
 
 const SearchContext = createContext<SearchContextType>(null);

--- a/src/apps/search/SearchLayout.tsx
+++ b/src/apps/search/SearchLayout.tsx
@@ -63,10 +63,16 @@ const SearchLayout = () => {
     maxZoom: config.map.max_zoom || DEFAULT_MAX_ZOOM
   }), [config, left, id, view]);
 
+  /**
+   * Memo-izes the class to apply to the map controls container.
+   */
+  const controlsClass = useMemo(() => id ? 'me-[350px]' : null, [id]);
+
   return (
     <SearchContext.Provider
       value={{
-        boundingBoxOptions
+        boundingBoxOptions,
+        controlsClass
       }}
     >
       <div


### PR DESCRIPTION
This pull request adds a margin to the map controls container when a detail panel is visible to prevent it from being hidden by the panel.

![Screenshot 2025-03-04 at 2 40 11 PM](https://github.com/user-attachments/assets/6103a9b2-e473-4c50-9c5d-b67e88b5bff2)
![Screenshot 2025-03-04 at 2 40 19 PM](https://github.com/user-attachments/assets/331212d8-2f20-44bf-aaa7-1fd100791e0f)
