### PR TITLE
Making `LanguagePicker` dropdown text black

### DIFF
--- a/src/components/LanguagePicker.tsx
+++ b/src/components/LanguagePicker.tsx
@@ -49,7 +49,7 @@ const LanguagePicker = (props: Props) => {
           leaveTo='opacity-0'
         >
           <Listbox.Options
-            className='absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm z-10'
+            className='absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm z-10 text-black'
           >
             { locales.map((locale, idx) => (
               <Listbox.Option


### PR DESCRIPTION
### In this PR
Addresses Issue #107 by specifying that the text in the language picker dropdown should be black.