### PR TITLE
CDP #120 - MongoDB collection name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,10 @@ TINA_PUBLIC_IS_LOCAL=false
 # Relative path to the local TinaCMS GitHub content repository
 TINA_LOCAL_CONTENT_PATH=../../my-content-repo
 
-# Name of the MongoDB database. For production instances, this should be "tinacms"
+# Name of the MongoDB collection. This value should be unique for all deploys.
+MONGODB_COLLECTION_NAME=my_collection
+
+# Name of the MongoDB database. For production instances, this should be "tinacms".
 MONGODB_NAME=my_database
 
 # URI of the MongoDB database

--- a/tina/database.ts
+++ b/tina/database.ts
@@ -13,6 +13,8 @@ const branch =
   process.env.HEAD ||
   'main';
 
+const deployContext = process.env.DEPLOY_CONTEXT || 'deploy-preview';
+
 export default isLocal
   ? createLocalDatabase()
   : createDatabase({
@@ -23,7 +25,7 @@ export default isLocal
       token: process.env.GITHUB_PERSONAL_ACCESS_TOKEN!,
     }),
     databaseAdapter: new MongodbLevel<string, Record<string, unknown>>({
-      collectionName: `${process.env.GITHUB_REPO}-${branch}`,
+      collectionName: `${process.env.GITHUB_REPO}-${branch}-${deployContext}`,
       dbName: process.env.MONGODB_NAME!,
       mongoUri: process.env.MONGODB_URI!,
     })

--- a/tina/database.ts
+++ b/tina/database.ts
@@ -13,8 +13,6 @@ const branch =
   process.env.HEAD ||
   'main';
 
-const deployContext = process.env.DEPLOY_CONTEXT || 'deploy-preview';
-
 export default isLocal
   ? createLocalDatabase()
   : createDatabase({
@@ -25,7 +23,7 @@ export default isLocal
       token: process.env.GITHUB_PERSONAL_ACCESS_TOKEN!,
     }),
     databaseAdapter: new MongodbLevel<string, Record<string, unknown>>({
-      collectionName: `${process.env.GITHUB_REPO}-${branch}-${deployContext}`,
+      collectionName: process.env.MONGODB_COLLECTION_NAME || `${process.env.GITHUB_REPO}-${branch}`,
       dbName: process.env.MONGODB_NAME!,
       mongoUri: process.env.MONGODB_URI!,
     })


### PR DESCRIPTION
This pull request adds the ability to define a `MONGODB_COLLECTION_NAME` environment variable, which will be used as the name of the collection in the Mongo Database. This will allow us to use separate MongoDB collections for the production, preview, and branch deploys of a single site.

**Note:** We couldn't just use a unique value because the MongoDB collections are never removed. Deploy previews for the same site will share the same collection. This has the ability to cause conflicts, but will not cause conflicts with the production version of the site.

![Screenshot 2025-03-12 at 9 14 40 AM](https://github.com/user-attachments/assets/80d2781c-7475-4a21-92d7-293091fcd6c9)