### PR TITLE
Fixing button text color in footer

### DIFF
--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -80,7 +80,7 @@ const { title } = await fetchAbout();
             href={config.core_data.url}
             target='_blank'
           >
-            <Button client:only rounded className='bg-white'>
+            <Button client:only rounded className='bg-white text-black hover:text-inherit'>
               <p>
                 { t('coreDataLogin') }
               </p>
@@ -90,7 +90,7 @@ const { title } = await fetchAbout();
             href='/admin/index.html'
             target='_blank'
           >
-            <Button client:only rounded className='bg-white'>
+            <Button client:only rounded className='bg-white text-black hover:text-inherit'>
               <p>
                 { t('tinaLogin') }
               </p>


### PR DESCRIPTION
### In this PR
In the case that the primary color is dark, the text on the footer buttons ends up white-on-white (see Issue #126 ). This PR fixes that by making the text black in the non-hover state. 
![image](https://github.com/user-attachments/assets/71c699ee-35cb-48ef-ac4e-c594eabff93e)
