### PR TITLE
Bug fix: Added `relatedPeople` back to record detail panel

### DIFF
--- a/src/apps/search/panels/BasePanel.tsx
+++ b/src/apps/search/panels/BasePanel.tsx
@@ -47,7 +47,6 @@ const BasePanel = (props: Props) => {
   const id = getCurrentId(route);
 
   const exclude = props.exclusions || [];
-  console.log(exclude);
 
   const { boundingBoxOptions } = useContext(SearchContext);
 


### PR DESCRIPTION
### In this PR
Addresses at least part of Issue #131 by adding a line that was missing to the `relations()` function in `BasePanel`, so that related people records are properly included.