### PR TITLE
Disable pagination on relations Core Data API request

### DIFF
--- a/src/loaders/api/helpers.ts
+++ b/src/loaders/api/helpers.ts
@@ -37,7 +37,7 @@ export async function getRelation(
   relatedModel: string
 ) {
   const url = new URL(
-    `${path}${model}/${uuid}/${relatedModel}?${createProjectIdString(config.core_data.project_ids)}`,
+    `${path}${model}/${uuid}/${relatedModel}?${createProjectIdString(config.core_data.project_ids)}&per_page=-1`,
     config.core_data.url
   );
   const response = await fetch(url).then((res) => res.json());


### PR DESCRIPTION
# Summary

This PR adds the `per_page=-1` param to the URL that `getRelation` uses to fetch related records, disabling the per-page limit. Previously, it was limited to Core Data's default pagination limit of 10.

In the long run, we should migrate the loader to use `@performant-software/core_data`'s service helpers, unblocked by https://github.com/performant-software/react-components/pull/475. But this is a really quick short-term fix.