### PR TITLE
CDP #151 - Disable TinaCMS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ STATIC_BUILD=false
 # URL for a georeferenced map library JSON, which should retrieve an array of objects with "name" and "url" keys.
 TINA_PUBLIC_MAP_LIBRARY_URL=https://...
 
+# If true, content loaders will not be run. This option is useful in development environments when we don't want to
+# load all of the data each time the development server restarts.
+USE_CONTENT_CACHE=false
+
 # Configuration for Keycloak SSO login if relevant
 AUTH_KEYCLOAK_ID=tinacms
 AUTH_KEYCLOAK_ISSUER=https://keycloak.archivengine.com/realms/your-realm

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,10 +4,11 @@ import { defineCollection } from 'astro:content';
 import _ from 'underscore';
 
 const isStaticBuild = !!import.meta.env.STATIC_BUILD;
+const useContentCache = !!import.meta.env.USE_CONTENT_CACHE;
 
 let cols = {};
 
-if (isStaticBuild) {
+if (isStaticBuild && !useContentCache) {
   for (const model of modelTypes) {
     cols[model.model] = defineCollection({
       loader: coreDataLoader({

--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -34,20 +34,24 @@ const { title } = await fetchAbout();
         </div>
       )
     }
-    <div class='flex flex-col items-center w-full'>
+    <div
+      class='flex flex-col items-center w-full'
+    >
       <div
         class='flex flex-col md:flex-row gap-6 align-middle justify-center items-center pt-8'
       >
         {
           !config.branding?.footer_hide_title ? (
             <>
-              { 
-                config.branding?.footer_logo && <img           
+              { config.branding?.footer_logo && (
+                <img
                   class='h-14'
                   src={config.branding?.footer_logo}
                 />
-              }
-              <h1 class='font-serif font-semibold text-[32px] text-center'>
+              )}
+              <h1
+                class='font-serif font-semibold text-[32px] text-center'
+              >
                 { title }
               </h1>
             </>
@@ -71,34 +75,36 @@ const { title } = await fetchAbout();
         ))}
       </div>
     </div>
-    {
-      config.branding?.footer_login && (
-        <div
-          class='flex flex-row justify-center gap-8 py-8 w-full'
+    { config.branding?.footer_login && !import.meta.env.STATIC_BUILD && (
+      <div
+        class='flex flex-row justify-center gap-8 py-8 w-full'
+      >
+        <a
+          href={config.core_data.url}
+          target='_blank'
         >
-          <a
-            href={config.core_data.url}
-            target='_blank'
+          <Button
+            className='bg-white text-black hover:text-inherit'
+            rounded
+            client:only
           >
-            <Button client:only rounded className='bg-white text-black hover:text-inherit'>
-              <p>
-                { t('coreDataLogin') }
-              </p>
-            </Button>
-          </a>
-          <a
-            href='/admin/index.html'
-            target='_blank'
+            { t('coreDataLogin') }
+          </Button>
+        </a>
+        <a
+          href='/admin/index.html'
+          target='_blank'
+        >
+          <Button
+            className='bg-white text-black hover:text-inherit'
+            rounded
+            client:only
           >
-            <Button client:only rounded className='bg-white text-black hover:text-inherit'>
-              <p>
-                { t('tinaLogin') }
-              </p>
-            </Button>
-          </a>
-        </div>
-      )
-    }
+            { t('tinaLogin') }
+          </Button>
+        </a>
+      </div>
+    )}
     <p
       class='text-center text-sm py-8 w-full'
     >

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,6 @@ export interface Configuration {
   branding?: {
     header_hide_title?: boolean,
     footer_hide_logo?: boolean,
-    footer_hide_title?: boolean,
     footer_login?: boolean,
     footer_logo?: string,
     footer_orgs?: Array<{ alt: string, logo: string, url: string }>,


### PR DESCRIPTION
This pull request updates the `Footer` component to hide the Core Data and TinaCMS login buttons when we're building the site in "static" mode. 

It also adds the optional `USE_CONTENT_CACHE` environment variable to allow the site to be built in "static" mode without running the content loaders. This is useful in a dev environment when the dev server may be restarted multiple times.

![Screenshot 2025-04-01 at 7 26 47 AM](https://github.com/user-attachments/assets/2815db16-b307-44d7-beab-ba78cc19ab21)
