### PR TITLE
CDP #117 - Data visualizations

### DIFF
--- a/tina/components/MapInput.tsx
+++ b/tina/components/MapInput.tsx
@@ -21,7 +21,8 @@ const MapInput = wrapFieldsWithMeta((props) => {
     const { name, data: records } = JSON.parse(data);
     const searchConfig = _.findWhere(config.search, { name });
 
-    const attributes = _.compact([...ATTRIBUTES, searchConfig.map.geometry || undefined]);
+    const geometryAttribute = _.first(searchConfig.map.geometry.split('.'));
+    const attributes = _.compact([...ATTRIBUTES, geometryAttribute]);
     const value = _.map(records, (record) => _.pick(record, ...attributes));
 
     props.input.onChange(JSON.stringify({ name, data: value }));

--- a/tina/components/TableInput.tsx
+++ b/tina/components/TableInput.tsx
@@ -17,7 +17,7 @@ const TableInput = wrapFieldsWithMeta((props) => {
 
     const columns = [
       searchConfig.result_card.title,
-      ..._.pluck(config.result_card.attributes?.slice(0, MAX_ATTRIBUTES), 'name')
+      ..._.pluck(searchConfig.result_card.attributes?.slice(0, MAX_ATTRIBUTES), 'name')
     ];
 
     const rows = _.map(records, (record) => {


### PR DESCRIPTION
This pull request fixes two separate issues with the MapInput and TableInput components:

## MapInput
We were not correctly getting the geometry data when the `search.map.geometry` attribute was a path to a nested record (e.g. for non-place records).

## TableInput
We were not using the search-specific configuration to pull the table attributes from the config.