### PR TITLE
Troubleshooting image uploads

### DIFF
--- a/netlify/functions/tina.ts
+++ b/netlify/functions/tina.ts
@@ -107,6 +107,8 @@ app.get('/api/tina/*', async (req, res) => {
 
 app.get('/api/s3/media', mediaHandler);
 
+app.get('/api/s3/media/*', mediaHandler);
+
 app.post('/api/s3/media', mediaHandler);
 
 app.delete('/api/s3/media/:media', (req, res) => {


### PR DESCRIPTION
### In this PR
Attempting to fix media uploads via Tina. Adding the catch-all route for `/api/s3/images/*` seems to fix one level of the issue, but now I am running into a different issue where it seems that the `S3_FOLDER` environment variable isn't being used correctly and it's just trying to upload the image directly to the parent folder of the bucket. 
![image](https://github.com/user-attachments/assets/a7acd29f-f4f9-400b-96d9-495c173ca6e2)
![image](https://github.com/user-attachments/assets/5659db45-4abc-4306-aa0c-08af71dda060)
