### PR TITLE
Add "map" object back to tina settings collection (#162)

### DIFF
--- a/tina/content/settings.ts
+++ b/tina/content/settings.ts
@@ -275,6 +275,27 @@ const Settings: Collection = {
         }]
       }]
     }, {
+      name: 'map',
+      label: 'Map',
+      type: 'object',
+      fields: [{
+        name: 'cluster_radius',
+        label: 'Cluster Radius',
+        type: 'number'
+      }, {
+        name: 'geometry',
+        label: 'Geometry',
+        type: 'string'
+      }, {
+        name: 'max_zoom',
+        label: 'Max zoom',
+        type: 'number'
+      }, {
+        name: 'zoom_to_place',
+        label: 'Zoom to place',
+        type: 'boolean'
+      }]
+    }, {
       name: 'result_card',
       label: 'Result card',
       type: 'object',


### PR DESCRIPTION
Per #162:
- Add the `map` object back to Tina search settings 

Noticed this when I edited the timeline config in Tina for the scavenger hunt site, looks like this was accidentally removed during the big config update.