### PR TITLE
Fix typo in works pane route

### DIFF
--- a/src/apps/search/SearchRoutes.tsx
+++ b/src/apps/search/SearchRoutes.tsx
@@ -23,7 +23,7 @@ const SearchRoutes = (props: Props) => (
       element={<Instance className={props.className} />}
     />
     <Route
-      match='/item/'
+      match='/items/'
       element={<Item className={props.className} />}
     />
     <Route

--- a/src/apps/search/SearchRoutes.tsx
+++ b/src/apps/search/SearchRoutes.tsx
@@ -39,7 +39,7 @@ const SearchRoutes = (props: Props) => (
       element={<Place className={props.className} />}
     />
     <Route
-      match='/work/'
+      match='/works/'
       element={<Work className={props.className} />}
     />
     <Route


### PR DESCRIPTION
# Summary

After following a bunch of red herring error messages in the console, I discovered that #155 was caused by a typo in the `SearchRoutes` component. It was matching `/work` instead of `/works`. The `/items` route had the same issue, so I also fixed that one.