### PR TITLE
Ensure map bounding box updated when timeline is opened (#164)

### DIFF
--- a/src/apps/search/SearchLayout.tsx
+++ b/src/apps/search/SearchLayout.tsx
@@ -88,7 +88,7 @@ const SearchLayout = () => {
       right: rightOpen ? PADDING_RIGHT_DETAIL: DEFAULT_PADDING_RIGHT
     },
     maxZoom: config.map.max_zoom || DEFAULT_MAX_ZOOM
-  }), [config, left, rightOpen, view]);
+  }), [config, left, rightOpen, bottomOpen]);
 
   /**
    * Updates the class to apply to the map controls container.


### PR DESCRIPTION
## In this PR

Per #164:
- Add `bottomOpen` to dependencies for the `setBoundingBoxOptions` `useEffect` call (instead of `view`, whose value is not read by it and is used in the calculation of `bottomOpen`)