### PR TITLE
CDP #152 - Post content

### DIFF
--- a/src/apps/posts/PlaceInsert.tsx
+++ b/src/apps/posts/PlaceInsert.tsx
@@ -14,10 +14,10 @@ const PlaceInsert = (props: any) => {
 
   return (
     <div
-      className='flex flex-col gap-y-2 place-content-center mx-auto my-8 w-full'
+      className='flex flex-col gap-y-2 my-8 w-full'
     >
       <div
-        className='h-[400px] w-3/4 flex mx-auto'
+        className='h-[400px] w-3/4 flex w-full'
       >
         <PlacesMap
           layer={props.place?.layer}

--- a/src/pages/[lang]/posts/[slug].astro
+++ b/src/pages/[lang]/posts/[slug].astro
@@ -39,7 +39,7 @@ export const getStaticPaths = async () => {
   title={slug}
 >
   <Container
-    className='pb-16'
+    className='pb-16 w-full'
   >
     <PostContent
       content={post?.body}

--- a/src/visualizations/Table.tsx
+++ b/src/visualizations/Table.tsx
@@ -26,7 +26,7 @@ const Table = (props: DataVisualizationProps) => {
       title={props.title}
     >
       <div
-        className='bg-white not-prose p-3'
+        className='bg-white not-prose py-3'
       >
         <SearchResultsTable
           columns={columns}


### PR DESCRIPTION
This pull request fixes a bug where the `margin: auto` CSS was causing an issue within a flexbox container for the post content. The solution was to add the `w-full` class to the container in order to set the width to "100%".

This pull request also fixes an issue with the map component not taking up the entire width of the container. To fix that, I removed the `mx-auto` class on the child containers and added `w-full`.

Finally, this pull request removes the horizontal padding on the Table visualization container to align the table with the header/content.

## Post page
![Screenshot 2025-04-07 at 11 42 06 AM](https://github.com/user-attachments/assets/f93bbc2e-afc3-48da-b061-a4b25eba4c15)

## Post with table
![Screenshot 2025-04-07 at 11 43 05 AM](https://github.com/user-attachments/assets/aeb1d80c-9aca-43b2-a386-965662ee9d10)
