### PR TITLE
CDP #117 - Data Visualizations

### DIFF
--- a/src/backend/api/coreData/base.ts
+++ b/src/backend/api/coreData/base.ts
@@ -142,10 +142,10 @@ class Base {
       url.push(searchParams.toString());
     }
 
-    const response = await fetch(url.join(''))
-    const json = await response.json()
+    const response = await fetch(url.join(''));
+    const json = await response.json();
 
-    return json
+    return json;
   }
 }
 


### PR DESCRIPTION
This pull request updates the `EventsByYearInput` component to use the uploaded Typesense data to construct the visualization data set, rather than making a request to Core Data.

The issue is that we don't send any search parameters to the Astro API endpoints. This is because in "static" mode, we don't have a server, so all of the data is loaded as JSON. We want to keep the data flow consistent between both modes.

As a result, the `id` parameter was not being passed to Core Data, which resulted in the request returning no results. As a solution, we'll simply build the visualization dataset from the Typesense data.