### PR TITLE
CDP #177 - Timeline embed

### DIFF
--- a/src/pages/[lang]/posts/index.astro
+++ b/src/pages/[lang]/posts/index.astro
@@ -22,7 +22,7 @@ export const getStaticPaths = () => _.map(config.i18n.locales, (lang) => ({ para
   title={t('posts')}
 >
   <Container
-    className='pb-16'
+    className='pb-16 w-full'
   >
     <h1
       class='text-3xl my-12'

--- a/tina/components/TimelineInput.tsx
+++ b/tina/components/TimelineInput.tsx
@@ -1,5 +1,6 @@
 import config from '@config';
 import { FuzzyDate as FuzzyDateUtils, ObjectJs as ObjectUtils } from '@performant-software/shared-components';
+import { includeTimeline } from '@root/tina/utils/visualizations';
 import { useCallback, useState } from 'react';
 import { wrapFieldsWithMeta } from 'tinacms';
 import _ from 'underscore';
@@ -72,7 +73,7 @@ const TimelineInput = wrapFieldsWithMeta((props) => {
     const { name, data: records } = JSON.parse(data);
     const searchConfig = _.findWhere(config.search, { name });
 
-    if (_.has(searchConfig.timeline, 'event_path')) {
+    if (includeTimeline(searchConfig)) {
       setInputValue(records, searchConfig);
     } else {
       setError('The uploaded dataset does not support the "Timeline" visualization.');

--- a/tina/content/visualizations.ts
+++ b/tina/content/visualizations.ts
@@ -4,6 +4,7 @@ import MapInput from '@root/tina/components/MapInput';
 import TableInput from '@root/tina/components/TableInput';
 import TimelineInput from '@root/tina/components/TimelineInput';
 import { createDataVisualization } from '@root/tina/utils/content';
+import { includeTimeline } from '@root/tina/utils/visualizations';
 import _ from 'underscore';
 
 export const Visualizations = {
@@ -25,8 +26,8 @@ const schema = [
 ];
 
 // Add "timeline" visualization if the site includes a timeline
-const includeTimeline = _.some(config.search, (search) => !_.isEmpty(search.timeline));
-if (includeTimeline) {
+const includeTimelineVisualization = _.some(config.search, (search) => includeTimeline(search));
+if (includeTimelineVisualization) {
   schema.push(createDataVisualization({
     name: 'timeline',
     label: 'Timeline',

--- a/tina/utils/visualizations.ts
+++ b/tina/utils/visualizations.ts
@@ -1,0 +1,8 @@
+import _ from 'underscore';
+
+/**
+ * Returns true if the timeline embed is available for the passed search configuration.
+ *
+ * @param config
+ */
+export const includeTimeline = (config) => !_.isEmpty(config.timeline);


### PR DESCRIPTION
This pull request fixes an issue where the Timeline embed was not available in a post record unless the `event_path` configuration option was explicitly set, which should not be necessary for event-based indexes. The solution was to add a utility method to check whether to include the Timeline, which will be available to the two places that use it.

Additionally, this pull request fixes a layout issue with the posts index page.

![Screenshot 2025-04-08 at 2 32 33 PM](https://github.com/user-attachments/assets/d0343537-ad7b-4760-988a-690ef770eb64)
