### PR TITLE
Cover images for detail pages

### DIFF
--- a/src/apps/pages/RecordDetail/PlaceMap.tsx
+++ b/src/apps/pages/RecordDetail/PlaceMap.tsx
@@ -6,16 +6,12 @@ import TranslationContext from '@contexts/TranslationContext';
 import { useTranslations } from '@i18n/useTranslations';
 
 interface Props {
-  record: any;
+  geometry: any;
   lang: string;
 }
 
 const PlaceMap = (props: Props) => {
   const { t } = useTranslations();
-
-  if (!props.record.place_geometry?.geometry_json) {
-    return null;
-  }
 
   return (
     <TranslationContext.Provider
@@ -31,7 +27,7 @@ const PlaceMap = (props: Props) => {
               boundingBoxOptions={{
                 animate: false
               }}
-              data={props.record.place_geometry.geometry_json}
+              data={props.geometry}
             />
           </Map>
         </Peripleo>

--- a/src/apps/pages/RecordDetail/index.astro
+++ b/src/apps/pages/RecordDetail/index.astro
@@ -5,21 +5,25 @@ import { Icon } from '@performant-software/core-data/ssr'
 import MediaContents from "./MediaContents";
 import Container from "@components/Container.astro";
 import { getNameView } from "@utils/people";
+import PlaceMap from "./PlaceMap";
 
 interface Props {
+  coverUrl?: string;
   excludes: string[];
+  geometry?: any;
   lang: string;
   name: string;
   record: any;
 }
 
-const { excludes, lang, name, record } = Astro.props;
+const { coverUrl, excludes, geometry, lang, name, record } = Astro.props;
 
 const relations = {
   events: {},
   instances: {},
   items: {},
   manifests: record.relatedRecords?.manifests,
+  mediaContents: {},
   organizations: {},
   people: {},
   places: {},
@@ -60,6 +64,21 @@ for (const modelType of Object.keys(record.relatedRecords)) {
   </button>
   <div class="ml-12 divide-y divide-solid divide-[#e5e5e5]">
     <h1 class="font-bold text-3xl text-neutral-800 mt-0 mb-6">{name}</h1>
+    {(geometry || coverUrl) && (
+      <div class='h-[360px] py-6 mx-auto flex gap-6 w-full'>
+        {coverUrl && (
+          <img
+            class={`${geometry ? 'w-[30%]' : 'w-full'} h-full object-cover`}
+            src={coverUrl}
+          />
+        )}
+        {geometry && (
+          <div class={coverUrl ? 'w-[70%]' : 'w-full'}>
+            <PlaceMap client:only='react' lang={lang} geometry={geometry} />
+          </div>
+        )}
+      </div>
+    )}
     <slot />
     <UserDefined
       record={record}

--- a/src/pages/[lang]/events/[uuid]/index.astro
+++ b/src/pages/[lang]/events/[uuid]/index.astro
@@ -6,7 +6,7 @@ import { getTranslations } from '@backend/i18n';
 import EventsService from '@services/coreData/events';
 import { ModelNames } from '@services/coreData/factory';
 import { FuzzyDate as FuzzyDateUtils } from '@performant-software/shared-components';
-import { getDetailPagePaths } from '@utils/detailPages';
+import { getCoverImage, getDetailPagePaths, getRelatedGeometry } from '@utils/detailPages';
 
 const { t } = await getTranslations(Astro.currentLocale);
 
@@ -15,12 +15,17 @@ const { lang, uuid } = Astro.params;
 const { event } = await EventsService.getFull(uuid);
 const excludes = config.search?.result_filtering?.events?.exclude || [];
 
+const coverUrl = getCoverImage(event);
+const geometry = getRelatedGeometry(event);
+
 export const getStaticPaths = async () => await getDetailPagePaths(config, ModelNames.events);
 ---
 
 <Layout footer t={t} title={event.name}>
   <RecordDetail
+    coverUrl={coverUrl}
     excludes={excludes}
+    geometry={geometry}
     lang={lang}
     name={event.name}
     record={event}

--- a/src/pages/[lang]/instances/[uuid]/index.astro
+++ b/src/pages/[lang]/instances/[uuid]/index.astro
@@ -5,7 +5,7 @@ import RecordDetail from "@apps/pages/RecordDetail/index.astro";
 import { getTranslations } from '@backend/i18n';
 import { ModelNames } from '@services/coreData/factory';
 import InstancesService from '@services/coreData/instances';
-import { getDetailPagePaths } from "@utils/detailPages";
+import { getCoverImage, getDetailPagePaths, getRelatedGeometry } from "@utils/detailPages";
 
 const { t } = await getTranslations(Astro.currentLocale);
 
@@ -14,12 +14,17 @@ const { lang, uuid } = Astro.params;
 const { instance } = await InstancesService.getFull(uuid);
 const excludes = config.search?.result_filtering?.instances?.exclude || [];
 
+const coverUrl = getCoverImage(instance);
+const geometry = getRelatedGeometry(instance);
+
 export const getStaticPaths = async () => await getDetailPagePaths(config, ModelNames.instances);
 ---
 
 <Layout footer t={t} title={instance.name}>
   <RecordDetail
+    coverUrl={coverUrl}
     excludes={excludes}
+    geometry={geometry}
     lang={lang}
     name={instance.name}
     record={instance}

--- a/src/pages/[lang]/items/[uuid]/index.astro
+++ b/src/pages/[lang]/items/[uuid]/index.astro
@@ -5,7 +5,7 @@ import RecordDetail from "@apps/pages/RecordDetail/index.astro";
 import { getTranslations } from '@backend/i18n';
 import { ModelNames } from '@services/coreData/factory';
 import ItemsService from '@services/coreData/items';
-import { getDetailPagePaths } from "@utils/detailPages";
+import { getCoverImage, getDetailPagePaths, getRelatedGeometry } from "@utils/detailPages";
 
 const { t } = await getTranslations(Astro.currentLocale);
 
@@ -14,12 +14,17 @@ const { lang, uuid } = Astro.params;
 const { item } = await ItemsService.getFull(uuid);
 const excludes = config.search?.result_filtering?.items?.exclude || [];
 
+const coverUrl = getCoverImage(item);
+const geometry = getRelatedGeometry(item);
+
 export const getStaticPaths = async () => await getDetailPagePaths(config, ModelNames.items);
 ---
 
 <Layout footer t={t} title={item.name}>
   <RecordDetail
+    coverUrl={coverUrl}
     excludes={excludes}
+    geometry={geometry}
     lang={lang}
     name={item.name}
     record={item}

--- a/src/pages/[lang]/organizations/[uuid]/index.astro
+++ b/src/pages/[lang]/organizations/[uuid]/index.astro
@@ -5,7 +5,7 @@ import RecordDetail from "@apps/pages/RecordDetail/index.astro";
 import { getTranslations } from '@backend/i18n';
 import { ModelNames } from '@services/coreData/factory';
 import OrganizationsService from '@services/coreData/organizations';
-import { getDetailPagePaths } from "@utils/detailPages";
+import { getCoverImage, getDetailPagePaths, getRelatedGeometry } from "@utils/detailPages";
 
 const { t } = await getTranslations(Astro.currentLocale);
 
@@ -14,12 +14,17 @@ const { lang, uuid } = Astro.params;
 const { organization } = await OrganizationsService.getFull(uuid);
 const excludes = config.search?.result_filtering?.organizations?.exclude || [];
 
+const coverUrl = getCoverImage(organization);
+const geometry = getRelatedGeometry(organization);
+
 export const getStaticPaths = async () => await getDetailPagePaths(config, ModelNames.organizations);
 ---
 
 <Layout footer t={t} title={organization.name}>
   <RecordDetail
+    coverUrl={coverUrl}
     excludes={excludes}
+    geometry={geometry}
     lang={lang}
     name={organization.name}
     record={organization}

--- a/src/pages/[lang]/people/[uuid]/index.astro
+++ b/src/pages/[lang]/people/[uuid]/index.astro
@@ -6,7 +6,7 @@ import { getTranslations } from '@backend/i18n';
 import { ModelNames } from '@services/coreData/factory';
 import PeopleService from '@services/coreData/people';
 import { getNameView } from "@utils/people";
-import { getDetailPagePaths } from "@utils/detailPages";
+import { getCoverImage, getDetailPagePaths, getRelatedGeometry } from "@utils/detailPages";
 
 const { t } = await getTranslations(Astro.currentLocale);
 
@@ -14,6 +14,9 @@ const { lang, uuid } = Astro.params;
 
 const { person } = await PeopleService.getFull(uuid);
 const excludes = config.search?.result_filtering?.people?.exclude || [];
+
+const coverUrl = getCoverImage(person);
+const geometry = getRelatedGeometry(person);
 
 export const getStaticPaths = async () => await getDetailPagePaths(config, ModelNames.people);
 ---
@@ -24,6 +27,8 @@ export const getStaticPaths = async () => await getDetailPagePaths(config, Model
     lang={lang}
     name={getNameView(person)}
     record={person}
+    coverUrl={coverUrl}
+    geometry={geometry}
   >
     {person.biography && !excludes.includes('biography')
       ? <p class="text-neutral-800 py-6 break-words">{person.biography}</p>

--- a/src/pages/[lang]/places/[uuid]/index.astro
+++ b/src/pages/[lang]/places/[uuid]/index.astro
@@ -1,12 +1,11 @@
 ---
-import Layout from "@layouts/Layout.astro";
-import config from "@config";
-import RecordDetail from "@apps/pages/RecordDetail/index.astro";
+import Layout from '@layouts/Layout.astro';
+import config from '@config';
+import RecordDetail from '@apps/pages/RecordDetail/index.astro';
 import { getTranslations } from '@backend/i18n';
 import { ModelNames } from '@services/coreData/factory';
 import PlacesService from '@services/coreData/places';
-import PlaceMap from "@apps/pages/RecordDetail/PlaceMap";
-import { getDetailPagePaths } from '@utils/detailPages';
+import { getCoverImage, getDetailPagePaths } from '@utils/detailPages';
 
 const { t } = await getTranslations(Astro.currentLocale);
 
@@ -14,6 +13,9 @@ const { lang, uuid } = Astro.params;
 
 const { place } = await PlacesService.getFull(uuid);
 const excludes = config.search?.result_filtering?.places?.exclude || [];
+
+const coverUrl = getCoverImage(place);
+const geometry = place?.place_geometry?.geometry_json
 
 export const getStaticPaths = async () => await getDetailPagePaths(config, ModelNames.places);
 ---
@@ -24,15 +26,7 @@ export const getStaticPaths = async () => await getDetailPagePaths(config, Model
     lang={lang}
     name={place.name}
     record={place}
-  >
-    { !excludes.includes('place_geometry') && (
-      <div class="h-[360px] py-6 mx-auto">
-        <PlaceMap
-          client:only="react"
-          lang={lang}
-          record={place}
-        />
-      </div>
-    )}
-  </RecordDetail>
+    coverUrl={coverUrl}
+    geometry={!excludes.includes('place_geometry') ? geometry : null}
+  />
 </Layout>

--- a/src/pages/[lang]/works/[uuid]/index.astro
+++ b/src/pages/[lang]/works/[uuid]/index.astro
@@ -5,7 +5,7 @@ import RecordDetail from "@apps/pages/RecordDetail/index.astro";
 import { getTranslations } from '@backend/i18n';
 import { ModelNames } from '@services/coreData/factory';
 import WorksService from '@services/coreData/works';
-import { getDetailPagePaths } from "@utils/detailPages";
+import { getCoverImage, getDetailPagePaths, getRelatedGeometry } from "@utils/detailPages";
 
 const { t } = await getTranslations(Astro.currentLocale);
 
@@ -14,12 +14,17 @@ const { lang, uuid } = Astro.params;
 const { work } = await WorksService.getFull(uuid)
 const excludes = config.search?.result_filtering?.works?.exclude || []
 
+const coverUrl = getCoverImage(work);
+const geometry = getRelatedGeometry(work);
+
 export const getStaticPaths = async () => await getDetailPagePaths(config, ModelNames.works);
 ---
 
 <Layout footer t={t} title={work.name}>
   <RecordDetail
+    coverUrl={coverUrl}
     excludes={excludes}
+    geometry={geometry}
     lang={lang}
     name={work.name}
     record={work}

--- a/src/services/coreData/base.ts
+++ b/src/services/coreData/base.ts
@@ -66,6 +66,7 @@ class Base {
       const { events } = await this.getRelatedEvents(id);
       const { instances } = await this.getRelatedInstances(id);
       const { items } = await this.getRelatedItems(id);
+      const { mediaContents } = await this.getRelatedMediaContents(id);
       const { organizations } = await this.getRelatedOrganizations(id);
       const { people } = await this.getRelatedPeople(id);
       const { places } = await this.getRelatedPlaces(id);
@@ -80,6 +81,7 @@ class Base {
           instances,
           items,
           manifests,
+          mediaContents,
           organizations,
           people,
           places,
@@ -204,6 +206,24 @@ class Base {
 
     return manifests;
   }
+
+  /**
+   * Returns the related media contents for the record with the passed ID.
+   *
+   * @param id
+   */
+    async getRelatedMediaContents(id: string) {
+      let mediaContents;
+  
+      if (this.useCache()) {
+        mediaContents = await this.getRelatedRecords(id, 'mediaContents');
+      } else {
+        const response = await this.service.fetchRelatedMedia(id, REQUEST_PARAMS);
+        mediaContents = response.media_contents;
+      }
+  
+      return { mediaContents };
+    }
 
   /**
    * Returns the related organizations for the record with the passed ID.

--- a/src/utils/detailPages.ts
+++ b/src/utils/detailPages.ts
@@ -1,4 +1,5 @@
 import ServiceFactory from '@services/coreData/factory';
+import { CoreData as CoreDataUtils } from '@performant-software/core-data/ssr';
 
 type Models = 'events' | 'instances' | 'items' | 'mediaContents' | 'organizations' | 'people' | 'places' | 'works';
 
@@ -20,3 +21,19 @@ export const getDetailPagePaths = (async (config: any, model: Models) => {
 
   return routes;
 });
+
+export const getCoverImage = (record: any) => {
+  if (record?.relatedRecords?.mediaContents && record.relatedRecords.mediaContents.length > 0) {
+    return record.relatedRecords.mediaContents[0].content_iiif_url
+  }
+
+  return null
+}
+
+export const getRelatedGeometry = (record: any) => {
+  if (record?.relatedRecords?.places && record.relatedRecords.places.length > 0) {
+    return CoreDataUtils.toFeatureCollection(record.relatedRecords.places)
+  }
+
+  return null
+}


### PR DESCRIPTION
# Summary

This PR adds cover images to all models, and adds a related places map in the cover banner for non-place records.

When both a cover image and related places exist, the cover image takes up 30% of the width and the map takes up 70%. If only one is available, that component takes 100% of the width.

## Screenshot

<img width="1302" alt="Screenshot 2025-04-15 at 3 50 55 PM" src="https://github.com/user-attachments/assets/26b09538-4fbb-428d-a2a8-0ba5c47d0e84" />
