### PR TITLE
Adding `media_contents` to services factory

### DIFF
--- a/src/services/coreData/factory.ts
+++ b/src/services/coreData/factory.ts
@@ -12,6 +12,7 @@ export const ModelNames = {
   events: 'events',
   instances: 'instances',
   items: 'items',
+  mediaContents: 'media_contents',
   organizations: 'organizations',
   people: 'people',
   places: 'places',
@@ -42,6 +43,10 @@ const getService = (name: string) => {
 
     case ModelNames.items:
       service = ItemsService;
+      break;
+
+    case ModelNames.mediaContents:
+      service = MediaContentsService;
       break;
 
     case ModelNames.organizations:


### PR DESCRIPTION
### In this PR
Addresses Issue #208 by adding the missing `media_contents` case to `services/coreData/factory.ts`. 