### PR TITLE
Changed Clover version to 2.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@performant-software/shared-components": "^3.0.4",
         "@peripleo/maplibre": "^0.8.7",
         "@peripleo/peripleo": "^0.8.7",
-        "@samvera/clover-iiif": "^2.12.2",
+        "@samvera/clover-iiif": "2.9.1",
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.4",
         "@tinacms/cli": "^1.9.2",
@@ -3516,36 +3516,24 @@
         "react": "*"
       }
     },
-    "node_modules/@iiif/helpers": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@iiif/helpers/-/helpers-1.3.1.tgz",
-      "integrity": "sha512-zVqgvvrUhKVq8JR1Gz8VXp+dD3SDdleAg/yJfGJ7cFvqFXiNQRtgY1ZbKxUfj/5ej5w5pgD/UuFF+E2CjcbxwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@iiif/presentation-2": "1.0.4",
-        "@iiif/presentation-3": "2.2.3",
-        "@iiif/presentation-3-normalized": "0.9.7",
-        "@types/geojson": "7946.0.13"
-      },
-      "optionalDependencies": {
-        "abs-svg-path": "^0.1.1",
-        "parse-svg-path": "^0.1.2",
-        "svg-arc-to-cubic-bezier": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@iiif/parser": "^2.1.7"
-      }
-    },
     "node_modules/@iiif/parser": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-2.1.7.tgz",
-      "integrity": "sha512-a3NrHOdW6RbmUeBCFJ751FBBuzS251O7owbRjUHUvRRs9GoFwNIDk5slh9qP5FFHycIbuyWjyl1lIxbikxAq/g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.1.2.tgz",
+      "integrity": "sha512-yjbhSWBB+cWHjAgeWlMYgNydMxDGU1BO3JnmgxCclMcfi59JDsKHMXpgZpCNw+svcirBtIMD2u70KPFinr2pUA==",
       "license": "MIT",
       "dependencies": {
         "@iiif/presentation-2": "^1.0.4",
-        "@iiif/presentation-3": "^2.2.2",
-        "@iiif/presentation-3-normalized": "^0.9.7",
-        "@types/geojson": "^7946.0.10"
+        "@iiif/presentation-3": "^1.1.3",
+        "@types/geojson": "^7946.0.8"
+      }
+    },
+    "node_modules/@iiif/parser/node_modules/@iiif/presentation-3": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-1.1.3.tgz",
+      "integrity": "sha512-Ek+25nkQouo0pXAqCsWYbAeS4jLDEBQA7iul2jzgnvoJrucxDQN2lXyNLgOUDRqpTdSqJ69iz5lm6DLaxil+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.7"
       }
     },
     "node_modules/@iiif/presentation-2": {
@@ -3562,17 +3550,9 @@
       "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-2.2.3.tgz",
       "integrity": "sha512-xCLbUr9euqegsrxGe65M2fWbv6gKpiUhHXCpOn+V+qtawkMbOSNWbYOISo2aLQdYVg4DGYD0g2bMzSCF33uNOQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "^7946.0.10"
-      }
-    },
-    "node_modules/@iiif/presentation-3-normalized": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@iiif/presentation-3-normalized/-/presentation-3-normalized-0.9.7.tgz",
-      "integrity": "sha512-Aqk0sYBFIH5W3wmVxW02tnAFbNzUU5oPygGQjvszB3PP2nSkFQ1skVjqJhQPPZTyi/de1qcJUrgSy0vp6s+c5A==",
-      "license": "MIT",
-      "dependencies": {
-        "@iiif/presentation-3": "^2.0.5"
       }
     },
     "node_modules/@iiif/vault": {
@@ -3618,17 +3598,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.7"
-      }
-    },
-    "node_modules/@iiif/vault/node_modules/@iiif/parser": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.1.2.tgz",
-      "integrity": "sha512-yjbhSWBB+cWHjAgeWlMYgNydMxDGU1BO3JnmgxCclMcfi59JDsKHMXpgZpCNw+svcirBtIMD2u70KPFinr2pUA==",
-      "license": "MIT",
-      "dependencies": {
-        "@iiif/presentation-2": "^1.0.4",
-        "@iiif/presentation-3": "^1.1.3",
-        "@types/geojson": "^7946.0.8"
       }
     },
     "node_modules/@iiif/vault/node_modules/@iiif/presentation-3": {
@@ -5021,82 +4990,6 @@
         "react": ">= 16.13.1 < 19.0.0",
         "react-dom": ">= 16.13.1 < 19.0.0",
         "tailwindcss": "^4.1.4"
-      }
-    },
-    "node_modules/@performant-software/core-data/node_modules/@iiif/parser": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.1.2.tgz",
-      "integrity": "sha512-yjbhSWBB+cWHjAgeWlMYgNydMxDGU1BO3JnmgxCclMcfi59JDsKHMXpgZpCNw+svcirBtIMD2u70KPFinr2pUA==",
-      "license": "MIT",
-      "dependencies": {
-        "@iiif/presentation-2": "^1.0.4",
-        "@iiif/presentation-3": "^1.1.3",
-        "@types/geojson": "^7946.0.8"
-      }
-    },
-    "node_modules/@performant-software/core-data/node_modules/@iiif/presentation-3": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-1.1.3.tgz",
-      "integrity": "sha512-Ek+25nkQouo0pXAqCsWYbAeS4jLDEBQA7iul2jzgnvoJrucxDQN2lXyNLgOUDRqpTdSqJ69iz5lm6DLaxil+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      }
-    },
-    "node_modules/@performant-software/core-data/node_modules/@samvera/clover-iiif": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.9.1.tgz",
-      "integrity": "sha512-aW5M6A3r1Y0fvSWOginPU+lsiaWl2aYvw4cbkZotBP+BztIUmI+bzS/Um2yDSnVeOZRsZ55DYAAVgjj9lRtYEA==",
-      "license": "ISC",
-      "dependencies": {
-        "@iiif/parser": "^1.1.2",
-        "@iiif/vault": "^0.9.22",
-        "@iiif/vault-helpers": "^0.10.0",
-        "@nulib/use-markdown": "^0.2.1",
-        "@radix-ui/react-aspect-ratio": "^1.0.3",
-        "@radix-ui/react-collapsible": "^1.0.3",
-        "@radix-ui/react-form": "^0.0.3",
-        "@radix-ui/react-popover": "^1.0.7",
-        "@radix-ui/react-radio-group": "^1.1.3",
-        "@radix-ui/react-select": "^2.0.0",
-        "@radix-ui/react-switch": "^1.0.3",
-        "@radix-ui/react-tabs": "^1.0.4",
-        "@stitches/react": "^1.2.8",
-        "flexsearch": "^0.7.43",
-        "hls.js": "^1.5.3",
-        "node-webvtt": "^1.9.4",
-        "openseadragon": "^4.1.1",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-error-boundary": "^4.0.12",
-        "sanitize-html": "^2.11.0",
-        "swiper": "^9.4.1",
-        "uuid": "^9.0.1"
-      },
-      "peerDependencies": {
-        "swiper": "^9.0.0"
-      }
-    },
-    "node_modules/@performant-software/core-data/node_modules/swiper": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-9.4.1.tgz",
-      "integrity": "sha512-1nT2T8EzUpZ0FagEqaN/YAhRj33F2x/lN6cyB0/xoYJDMf8KwTFT3hMOeoB8Tg4o3+P/CKqskP+WX0Df046fqA==",
-      "funding": [
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
-        },
-        {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "ssr-window": "^4.0.2"
-      },
-      "engines": {
-        "node": ">= 4.7.0"
       }
     },
     "node_modules/@performant-software/geospatial": {
@@ -7441,86 +7334,37 @@
       ]
     },
     "node_modules/@samvera/clover-iiif": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.12.2.tgz",
-      "integrity": "sha512-NaSAXrfLe1hlUG1POSaQxYI8+ZcYRwOWYObEJTcfiYmG7o5XyuZiujyixPSCKonBWxbUPqzsx78Ny5pMl2zmMg==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.9.1.tgz",
+      "integrity": "sha512-aW5M6A3r1Y0fvSWOginPU+lsiaWl2aYvw4cbkZotBP+BztIUmI+bzS/Um2yDSnVeOZRsZ55DYAAVgjj9lRtYEA==",
       "license": "ISC",
       "dependencies": {
-        "@iiif/helpers": "^1.2.19",
-        "@iiif/parser": "^2.1.4",
-        "@nulib/use-markdown": "^0.2.2",
-        "@radix-ui/react-aspect-ratio": "^1.1.0",
-        "@radix-ui/react-checkbox": "^1.1.2",
-        "@radix-ui/react-collapsible": "^1.1.1",
+        "@iiif/parser": "^1.1.2",
+        "@iiif/vault": "^0.9.22",
+        "@iiif/vault-helpers": "^0.10.0",
+        "@nulib/use-markdown": "^0.2.1",
+        "@radix-ui/react-aspect-ratio": "^1.0.3",
+        "@radix-ui/react-collapsible": "^1.0.3",
         "@radix-ui/react-form": "^0.0.3",
-        "@radix-ui/react-popover": "^1.1.2",
-        "@radix-ui/react-radio-group": "^1.2.1",
-        "@radix-ui/react-select": "^2.1.2",
-        "@radix-ui/react-switch": "^1.1.1",
-        "@radix-ui/react-tabs": "^1.1.1",
+        "@radix-ui/react-popover": "^1.0.7",
+        "@radix-ui/react-radio-group": "^1.1.3",
+        "@radix-ui/react-select": "^2.0.0",
+        "@radix-ui/react-switch": "^1.0.3",
+        "@radix-ui/react-tabs": "^1.0.4",
         "@stitches/react": "^1.2.8",
         "flexsearch": "^0.7.43",
-        "hls.js": "^1.5.17",
-        "i18next": "^23.16.5",
-        "i18next-browser-languagedetector": "^8.0.0",
+        "hls.js": "^1.5.3",
         "node-webvtt": "^1.9.4",
         "openseadragon": "^4.1.1",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-error-boundary": "^4.1.2",
-        "react-i18next": "^15.1.1",
-        "react-lazy-load-image-component": "^1.6.2",
-        "sanitize-html": "^2.13.1",
-        "swiper": "^9.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-error-boundary": "^4.0.12",
+        "sanitize-html": "^2.11.0",
+        "swiper": "^9.4.1",
         "uuid": "^9.0.1"
       },
       "peerDependencies": {
         "swiper": "^9.0.0"
-      }
-    },
-    "node_modules/@samvera/clover-iiif/node_modules/i18next": {
-      "version": "23.16.8",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
-      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
-      }
-    },
-    "node_modules/@samvera/clover-iiif/node_modules/react-i18next": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.4.1.tgz",
-      "integrity": "sha512-ahGab+IaSgZmNPYXdV1n+OYky95TGpFwnKRflX/16dY04DsYYKHtVLjeny7sBSCREEcoMbAgSkFiGLF5g5Oofw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.0",
-        "html-parse-stringify": "^3.0.1"
-      },
-      "peerDependencies": {
-        "i18next": ">= 23.2.3",
-        "react": ">= 16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
       }
     },
     "node_modules/@samvera/clover-iiif/node_modules/swiper": {
@@ -22010,15 +21854,6 @@
         "@babel/runtime": "^7.12.0"
       }
     },
-    "node_modules/i18next-browser-languagedetector": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.4.tgz",
-      "integrity": "sha512-f3frU3pIxD50/Tz20zx9TD9HobKYg47fmAETb117GKGPrhwcSSPJDoCposXlVycVebQ9GQohC3Efbpq7/nnJ5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -23274,12 +23109,6 @@
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "license": "MIT"
-    },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -23315,12 +23144,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "license": "MIT"
     },
     "node_modules/lodash.uniqby": {
@@ -44915,19 +44738,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
-    },
-    "node_modules/react-lazy-load-image-component": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/react-lazy-load-image-component/-/react-lazy-load-image-component-1.6.3.tgz",
-      "integrity": "sha512-kdQYUDbuISF3T9El0sBLNoWrmPohqlytcG4ognLtHYjY8bZAsJ0/Ez+VaV+0QlVyUY3K6dDXkuQAz3GpvdjBkw==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1"
-      },
-      "peerDependencies": {
-        "react": "^15.x.x || ^16.x.x || ^17.x.x || ^18.x.x || ^19.x.x"
-      }
     },
     "node_modules/react-map-gl": {
       "version": "7.1.9",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@performant-software/shared-components": "^3.0.4",
     "@peripleo/maplibre": "^0.8.7",
     "@peripleo/peripleo": "^0.8.7",
-    "@samvera/clover-iiif": "^2.12.2",
+    "@samvera/clover-iiif": "2.9.1",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.4",
     "@tinacms/cli": "^1.9.2",


### PR DESCRIPTION
### In this PR
Specifies the version for the `@samvera/clover-iiif` package as `2.9.1`. This addresses https://github.com/performant-software/core-data-places/issues/211 by rolling back to a version without the error. Obviously this is a temporary solution since we don't want to be bound to the older version of Clover forever, but until https://github.com/performant-software/iiif-cloud/issues/94 is resolved this should allow the media insert to function.