### PR TITLE
CDP #218 - Labels

### DIFF
--- a/scripts/build.config.mjs
+++ b/scripts/build.config.mjs
@@ -6,8 +6,8 @@ export const fetchConfig = async () => {
   if (configUrl) {
     const response = await fetch(configUrl);
     const config = await response.json();
-    const content = JSON.stringify(config, null, 2);
 
+    const content = JSON.stringify(config, null, 2);
     fs.writeFileSync('./public/config.json', content, 'utf8');
 
     console.info('Using remote config.json');
@@ -17,4 +17,7 @@ export const fetchConfig = async () => {
   } else {
     console.info('Using local config.json');
   }
+
+  const data = fs.readFileSync('./public/config.json');
+  return JSON.parse(data);
 };

--- a/scripts/build.fields.mjs
+++ b/scripts/build.fields.mjs
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import config from '../public/config.json' with { type: 'json' };
 
 const CONTEXT_SEPARATOR = '->';
 
@@ -19,9 +18,11 @@ const getLabel = (field) => {
 /**
  * Pull in fields/labels from "/projects/:project_id/descriptors".
  *
+ * @param config
+ *
  * @returns {Promise<void>}
  */
-export const buildUserDefinedFields = async () => {
+export const buildUserDefinedFields = async (config) => {
   const fields = {};
 
   for (const projectId of config.core_data.project_ids) {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -9,14 +9,14 @@ import { buildSearch } from './build.search.mjs';
   dotenv.config();
 
   console.log('Fetching config.json...');
-  await fetchConfig();
+  const config = await fetchConfig();
 
   console.log('Building userDefinedFields.json from Core Data descriptors...');
-  await buildUserDefinedFields();
+  await buildUserDefinedFields(config);
 
   console.log('Fetching content from repository...');
   await fetchContent();
 
   console.log('Building search.json from configuration...');
-  await buildSearch();
+  await buildSearch(config);
 }());

--- a/scripts/build.search.mjs
+++ b/scripts/build.search.mjs
@@ -1,7 +1,13 @@
 import fs from 'fs';
-import config from '../public/config.json' with { type: 'json' };
 
-export const buildSearch = async () => {
+/**
+ * Pulls in the search indexes from `config.json`.
+ *
+ * @param config
+ *
+ * @returns {Promise<void>}
+ */
+export const buildSearch = async (config) => {
   const searches = {};
 
   for (const search of config.search) {


### PR DESCRIPTION
This pull request fixes an issue in the custom build scripts which were preventing some labels from displaying correctly. Previously, each build script (`build.<type>.mjs`) was run indepdently as a Node process. The refactor in the previous release pulled them all into a single script. The `build.fields.mjs` and `build.search.mjs` scripts were importing the `config.json`, which caused a discrepency because the new build script was also writing to `config.json`.

The solution was to return the JSON data from the `build.config.mjs` script and pass it as an argument to the other scripts, rather than using an `import` statement.