### PR TITLE
CDP #236 - Static site

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,7 @@ import netlify from '@astrojs/netlify';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
-import { defineConfig } from 'astro/config';
+import { defineConfig, envField } from 'astro/config';
 import auth from 'auth-astro';
 import { loadEnv } from 'vite';
 import config from './public/config.json';
@@ -45,6 +45,22 @@ export default defineConfig({
         'jsnext:main',
         'jsnext'
       ]
+    }
+  },
+  env: {
+    schema: {
+      STATIC_BUILD: envField.boolean({
+        access: 'public',
+        context: 'client',
+        default: false,
+        optional: true
+      }),
+      USE_CONTENT_CACHE: envField.boolean({
+        access: 'public',
+        context: 'client',
+        default: false,
+        optional: true
+      })
     }
   }
 });

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,13 +1,11 @@
 import coreDataLoader from '@loaders/coreData';
 import i18nLoader from '@loaders/i18n';
+import { STATIC_BUILD, USE_CONTENT_CACHE } from "astro:env/client";
 import _ from 'underscore';
 
 const collections = {};
 
-const isStaticBuild = import.meta.env.STATIC_BUILD === true;
-const useContentCache = import.meta.env.USE_CONTENT_CACHE === true;
-
-if (isStaticBuild && !useContentCache) {
+if (STATIC_BUILD && !USE_CONTENT_CACHE) {
   _.extend(collections, { ...coreDataLoader, ...i18nLoader });
 }
 
@@ -15,4 +13,4 @@ export {
   collections
 };
 
-export const hasContentCollection = (name) => isStaticBuild && _.has(collections, name);
+export const hasContentCollection = (name: string) => STATIC_BUILD && _.has(collections, name);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -7,3 +7,8 @@ declare module '@performant-software/core-data/types/types/typesense';
 declare module '@performant-software/geospatial';
 declare module '@performant-software/shared-components';
 declare module 'underscore';
+
+declare module "astro:env/client" {
+  export const STATIC_BUILD: boolean;
+  export const USE_CONTENT_CACHE: boolean;
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,7 @@ import Footer from '@layouts/Footer.astro';
 import Header from '@layouts/Header.astro';
 import { useBlackText } from '@utils/layout';
 import { getPages } from '@utils/nav';
+import { STATIC_BUILD } from 'astro:env/client';
 import { getRelativeLocaleUrl } from 'astro:i18n';
 import _ from 'underscore';
 
@@ -34,8 +35,6 @@ const pages = await getPages(currentLocale);
 
 const { footer: includeFooter, fullscreen, name, title, t, tab } = Astro.props;
 
-const isStaticBuild = import.meta.env.STATIC_BUILD === true;
-
 const NavKeys = {
   search: 'search',
   pages: 'pages',
@@ -52,7 +51,7 @@ const searchOptions = _.map(config.search, (search) => ({
 }));
 
 // Add the "Saved Searches" option in "server" mode
-if (!isStaticBuild) {
+if (!STATIC_BUILD) {
   searchOptions.push({
     active: Astro.url.pathname.includes('/sessions/search'),
     name: 'search_session',
@@ -145,7 +144,7 @@ if (!_.isEmpty(NavConfig.pages.options)) {
       <Footer
         accessibilityUrl={footer?.accessibility_url}
         items={NavItems}
-        login={footer?.allow_login && !isStaticBuild}
+        login={footer?.allow_login && !STATIC_BUILD}
         logos={footer?.logos}
         privacyUrl={footer?.privacy_url}
         t={t}

--- a/src/pages/[lang]/search/[name]/index.astro
+++ b/src/pages/[lang]/search/[name]/index.astro
@@ -3,14 +3,13 @@ import Search from '@apps/search/Search';
 import { getTranslations } from '@backend/i18n';
 import config from '@config';
 import Layout from "@layouts/Layout.astro";
+import { STATIC_BUILD } from 'astro:env/client';
 import _ from 'underscore';
 
 const { lang } = Astro.params
 
 const { t } = await getTranslations(Astro.currentLocale);
 const { name } = Astro.params;
-
-const allowSave = import.meta.env.STATIC_BUILD !== true;
 
 export const getStaticPaths = () => {
   const paths = [];
@@ -33,7 +32,7 @@ export const getStaticPaths = () => {
   tab="search"
 >
   <Search
-    allowSave={allowSave}
+    allowSave={!STATIC_BUILD}
     lang={lang}
     name={name}
     client:only='react'

--- a/src/pages/api/session/[key]/[id].ts
+++ b/src/pages/api/session/[key]/[id].ts
@@ -21,3 +21,5 @@ export const GET: APIRoute = async ({ params, request, session }) => {
 
   return buildResponse(item);
 };
+
+export const getStaticPaths = () => [];

--- a/src/pages/api/session/[key]/index.ts
+++ b/src/pages/api/session/[key]/index.ts
@@ -38,3 +38,5 @@ export const POST: APIRoute = async ({ params, request, session }) => {
 
   return buildResponse(null);
 };
+
+export const getStaticPaths = () => [];

--- a/src/services/coreData/factory.ts
+++ b/src/services/coreData/factory.ts
@@ -20,9 +20,10 @@ export const ModelNames = {
 };
 
 /**
- * Returns the name of the models for which a service exists.
+ * Returns the name of the models for which a service exists. We'll exclude media_contents since we do not
+ * want to build static paths for media.
  */
-const getModels = () => _.values(ModelNames);
+const getModels = () => _.without(_.values(ModelNames), ModelNames.mediaContents);
 
 /**
  * Returns the service for the passed name.


### PR DESCRIPTION
This pull request fixes the following issues with building a static version of the site:

- Adds the missing `getStaticPaths` functions to the `/api/session/*` pages
- Updates `/services/coreData/factory` to _not_ return the media contents service, as this site does not provide API endpoints for that model
- Updates to use type-safe environment variables for `STATIC_BUILD` and `USE_CONTENT_CACHE`