### PR TITLE
Fix React hook error in `TimelineView`

### DIFF
--- a/src/apps/search/TimelineView.tsx
+++ b/src/apps/search/TimelineView.tsx
@@ -25,13 +25,6 @@ const TimelineView = (props: Props) => {
   const to = Math.min(max, Number.isFinite(start[1]) ? start[1] : max);
 
   /**
-   * Only display if the facet is available to refine.
-   */
-  if (!canRefine) {
-    return null;
-  }
-
-  /**
    * Sets the value on the state when the from/to values change.
    */
   useEffect(() => {
@@ -60,6 +53,13 @@ const TimelineView = (props: Props) => {
    * On event click, navigates to the selected event.
    */
   const onEventClick = useCallback((ev) => navigate(`/events/${ev.id}`), []);
+
+  /**
+   * Only display if the facet is available to refine.
+   */
+  if (!canRefine) {
+    return null;
+  }
 
   return (
     <div


### PR DESCRIPTION
# Summary

The `TimelineView` component has been crashing on https://atlas-project-staging.netlify.app when there are no search results matching the current search/filters.

This was caused by an early return in the component that was placed above its hooks. (see https://react.dev/errors/300?invariant=300). Moving the block with the return down below the hook calls fixes the error.