### PR TITLE
CDP #243 - Static Build (Posts/Paths)

### DIFF
--- a/src/pages/[lang]/paths/[slug].astro
+++ b/src/pages/[lang]/paths/[slug].astro
@@ -4,6 +4,7 @@ import { fetchPath, fetchPaths } from '@backend/tina';
 import config from '@config';
 import { getTranslations } from '@backend/i18n';
 import Layout from "@layouts/Layout.astro";
+import { hasPathsContent } from '@utils/config';
 import _ from 'underscore';
 
 const { slug } = Astro.params;
@@ -13,6 +14,10 @@ const { t } = await getTranslations(Astro.currentLocale);
 const title = path?.title || t('paths');
 
 export const getStaticPaths = async () => {
+  if (!hasPathsContent(config)) {
+    return [];
+  }
+
   const staticPaths = [];
 
   const locales = config.i18n.locales;

--- a/src/pages/[lang]/paths/index.astro
+++ b/src/pages/[lang]/paths/index.astro
@@ -6,13 +6,20 @@ import Cards from '@components/Cards.astro';
 import Container from '@components/Container.astro';
 import config from '@config';
 import Layout from '@layouts/Layout.astro';
+import { hasPathsContent } from '@utils/config';
 import { getRelativeLocaleUrl } from 'astro:i18n';
 import _ from 'underscore';
 
 const { t } = await getTranslations(Astro.currentLocale);
 const paths = await fetchPaths();
 
-export const getStaticPaths = () => _.map(config.i18n.locales, (lang) => ({ params: { lang }}));
+export const getStaticPaths = () => {
+  if (!hasPathsContent(config)) {
+    return [];
+  }
+
+  return _.map(config.i18n.locales, (lang: string) => ({ params: { lang }}));
+};
 
 ---
 

--- a/src/pages/[lang]/posts/[slug].astro
+++ b/src/pages/[lang]/posts/[slug].astro
@@ -5,6 +5,7 @@ import { fetchPost, fetchPosts } from '@backend/tina';
 import Container from '@components/Container.astro';
 import config from '@config';
 import Layout from '@layouts/Layout.astro';
+import { hasPostsContent } from '@utils/config';
 import _ from 'underscore';
 
 const { slug } = Astro.params;
@@ -13,6 +14,10 @@ const post = await fetchPost(slug);
 const { t } = await getTranslations(Astro.currentLocale);
 
 export const getStaticPaths = async () => {
+  if (!hasPostsContent(config)) {
+    return [];
+  }
+
   const staticPaths = [];
 
   const locales = config.i18n.locales;

--- a/src/pages/[lang]/posts/index.astro
+++ b/src/pages/[lang]/posts/index.astro
@@ -6,13 +6,20 @@ import Cards from '@components/Cards.astro';
 import Container from '@components/Container.astro';
 import config from '@config';
 import Layout from '@layouts/Layout.astro';
+import { hasPostsContent } from '@utils/config';
 import { getRelativeLocaleUrl } from 'astro:i18n';
 import _ from 'underscore';
 
 const { t } = await getTranslations(Astro.currentLocale);
 const posts = await fetchPosts();
 
-export const getStaticPaths = () => _.map(config.i18n.locales, (lang) => ({ params: { lang }}));
+export const getStaticPaths = () => {
+  if (!hasPostsContent(config)) {
+    return [];
+  }
+
+  return _.map(config.i18n.locales, (lang) => ({ params: { lang }}));
+}
 
 ---
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,14 +60,14 @@ export interface Configuration {
     project_ids: string[]
   };
 
-  detail_pages: Array<string>;
+  detail_pages?: Array<string>;
 
   i18n: {
     default_locale: string,
     locales: string[]
   },
 
-  layers: Array<{
+  layers?: Array<{
     name: string,
     layer_type: 'geojson' | 'vector' | 'raster' | 'georeference',
     url: string,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,27 @@
+import { Configuration } from '@types';
+import _ from 'underscore';
+
+const CONTENT_PATHS = 'paths';
+const CONTENT_POSTS = 'posts';
+
+/**
+ * Returns true if the passed configuration contains the passed content type.
+ *
+ * @param config
+ * @param contentType
+ */
+const hasContent = (config: Configuration, contentType: string) => _.contains(config.content?.collections, contentType);
+
+/**
+ * Returns true if the passed configuration includes paths content.
+ *
+ * @param config
+ */
+export const hasPathsContent = (config: Configuration) => hasContent(config, CONTENT_PATHS);
+
+/**
+ * Returns true if the passed configuration contains posts content.
+ *
+ * @param config
+ */
+export const hasPostsContent = (config: Configuration) => hasContent(config, CONTENT_POSTS);


### PR DESCRIPTION
This pull request fixes a bug with building a static version of the site. When the configuration file did not include "paths" or "posts" content types, we were still attempting to build those pages. This ran into an issue when fetching the data, because the TinaCMS schema did not contain those collections, the GraphQL endpoints didn't exist.

The solution was to check for the presence of the content types ("paths" or "posts") in the `getStaticPaths` functions on the Astro pages.