### PR TITLE
CDP #246 - Static site labels

### DIFF
--- a/src/loaders/coreData/helpers.ts
+++ b/src/loaders/coreData/helpers.ts
@@ -1,10 +1,10 @@
 import config from '@config';
-import { LoaderContext } from 'astro/dist/content/loaders';
+import type { LoaderContext } from 'astro/loaders';
 import _ from 'underscore';
 
 const RELATIONSHIP_ATTRIBUTES = [
   'uuid',
-  'project_model_relationship_id',
+  'project_model_relationship_uuid',
   'project_model_relationship_inverse'
 ];
 


### PR DESCRIPTION
This pull request fixes an issue where relationship labels were not displaying correctly when building a static version of the site. This was caused by the content loaders caching the `project_model_relationship_id` property instead of `project_model_relationship_uuid`, which is what is returned from the Core Data API.