### PR TITLE
v1.4.1 null geometry hotfix

### DIFF
--- a/src/apps/search/panels/BasePanel.tsx
+++ b/src/apps/search/panels/BasePanel.tsx
@@ -214,7 +214,10 @@ const { data: { people = [] } = {}, loading: peopleLoading } = useLoader(onLoadP
       return props.resolveGeometry(item);
     }
 
-    return !_.isEmpty(places) && CoreDataUtils.toFeatureCollection(places);
+    return !_.isEmpty(places.filter((place) => place.place_geometry)) &&
+      CoreDataUtils.toFeatureCollection(
+        places.filter((place) => place.place_geometry)
+      );
   }, [item, places, props.resolveGeometry]);
   
   /**

--- a/src/apps/search/panels/Place.tsx
+++ b/src/apps/search/panels/Place.tsx
@@ -48,7 +48,7 @@ const Place = (props: Props) => {
         </>
       )}
       resolveDetailPageUrl={resolveDetailPageUrl}
-      resolveGeometry={(place) => CoreDataUtils.toFeatureCollection([place])}
+      resolveGeometry={(place) => place?.place_geometry && CoreDataUtils.toFeatureCollection([place])}
       service={PlacesService}
     />
   );

--- a/src/loaders/coreData/helpers.ts
+++ b/src/loaders/coreData/helpers.ts
@@ -1,10 +1,10 @@
 import config from '@config';
-import { LoaderContext } from 'astro/dist/content/loaders';
+import type { LoaderContext } from 'astro/loaders';
 import _ from 'underscore';
 
 const RELATIONSHIP_ATTRIBUTES = [
   'uuid',
-  'project_model_relationship_id',
+  'project_model_relationship_uuid',
   'project_model_relationship_inverse'
 ];
 


### PR DESCRIPTION
### In this PR
A hotfix patch to fix the issue of the map search page crashing when a place with null geometry is opened in the detail panel.

Note that this does not fix the issue at the source; there should also be an update done to the `react-components` library to fix the `toFeatureCollection` method to fail more gracefully when passed null geometry.