### PR TITLE
Removing `: name(s)` specifier from facet labels

### DIFF
--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -49,12 +49,17 @@ export const getAttributes = (config) => config.result_card.attributes?.slice(0,
  */
 export const getFacetLabel = (attribute, t) => {
   let value;
+  
+  // exclude these from facet labels, e.g. 'Organizations' rather than 'Organizations: Name'
+  const DEFAULT_FIELDIDS = ["name", "names"]
 
   const relationshipId = TypesenseUtils.getRelationshipId(attribute);
   const fieldId = TypesenseUtils.getFieldId(attribute);
 
-  if (relationshipId && fieldId) {
+  if (relationshipId && fieldId && !DEFAULT_FIELDIDS.includes(fieldId)) {
     value = t('facetLabel', { relationship: t(relationshipId), field: t(fieldId) })
+  } else if (relationshipId) {
+    value = t(relationshipId);
   } else if (fieldId) {
     value = t(fieldId);
   }


### PR DESCRIPTION
### In this PR
The way that we currently create facet labels, for the `name` field of a related model we end up with e.g. `Organizations: Name`, which feels clunky and redundant and doesn't really add any info over just labeling the facet `Organizations`. In this PR I propose removing the specifier in the specific case that the field is the `name` or `names` field of the related model. This gives a cleaner look to the facets lists.

### Notes and questions
I realize that maybe ideally this would be configurable somehow project-by-project, but given that the facet configuration is already a bit overly confusing and that I can't actually imagine a case where it would be preferable to call the facet `<Related Model>: Name`, I'm starting with the very simplest implementation I could come up with. Open to other thoughts and suggestions though, of course.