### PR TITLE
Fixing some issues with `result_filtering` application

### DIFF
--- a/docs/search-detail-filtering.md
+++ b/docs/search-detail-filtering.md
@@ -1,6 +1,6 @@
 # Search detail filtering
 
-You can filter what is shown in the detail pane when clicking an item in the search view. This is accomplished by adding a result_filtering object to the search block in the config.json file in the content directory.
+You can filter what is shown in the detail pane when clicking an item in the search view. This is accomplished by adding a result_filtering object in the config.json file in the content directory.
 
 - To filter native fields add the name of the native field to the exclude array:
 

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -122,7 +122,7 @@ TINA_PUBLIC_AUTH_USE_KEYCLOAK=true
 }
 ```
 
-- `search.results_filtering` - an object specifying fields to exclude on the detail panel for different model types, e.g.
+- `search.result_filtering` - an object specifying fields to exclude on the detail panel for different model types, e.g.
 
 ```
 "result_filtering": {

--- a/src/apps/pages/RecordDetail/UserDefined.astro
+++ b/src/apps/pages/RecordDetail/UserDefined.astro
@@ -2,7 +2,7 @@
 import { getTranslations } from "@backend/i18n";
 import UserDefinedFieldView from "@components/UserDefinedFieldView";
 
-const { record } = Astro.props
+const { record, excludes } = Astro.props
 
 const lang = Astro.currentLocale;
 const { t } = await getTranslations(lang);
@@ -10,7 +10,7 @@ const { t } = await getTranslations(lang);
 {record.user_defined && (
   <>
     {Object.keys(record.user_defined).map(uuid => (
-      <div class="py-6">
+      !excludes.includes(uuid) && <div class="py-6">
         <h2 class="capitalize text-lg font-semibold">{t(uuid)}</h2>
         <div class="text-neutral-800 break-words">              
           <UserDefinedFieldView

--- a/src/apps/pages/RecordDetail/index.astro
+++ b/src/apps/pages/RecordDetail/index.astro
@@ -83,6 +83,7 @@ for (const modelType of Object.keys(record.relatedRecords)) {
     <slot />
     <UserDefined
       record={record}
+      excludes={excludes}
     />
     {relations.manifests && (
       <MediaContents

--- a/src/pages/[lang]/events/[uuid]/index.astro
+++ b/src/pages/[lang]/events/[uuid]/index.astro
@@ -13,7 +13,7 @@ const { t } = await getTranslations(Astro.currentLocale);
 const { lang, uuid } = Astro.params;
 
 const { event } = await EventsService.getFull(uuid);
-const excludes = config.search?.result_filtering?.events?.exclude || [];
+const excludes = config.result_filtering?.events?.exclude || [];
 
 const coverUrl = getCoverImage(event);
 const geometry = getRelatedGeometry(event);
@@ -35,7 +35,7 @@ export const getStaticPaths = async () => await getDetailPagePaths(config, Model
       if (event[field] && !excludes.includes(field)) {
         return (
           <div class="py-6">
-            <h2 class="capitalize text-lg font-semibold">{t('start_date')}</h2>
+            <h2 class="capitalize text-lg font-semibold">{t(field)}</h2>
             <div class="text-neutral-800">
               <p>{FuzzyDateUtils.getDateView(event[field])}</p>
             </div>

--- a/src/pages/[lang]/instances/[uuid]/index.astro
+++ b/src/pages/[lang]/instances/[uuid]/index.astro
@@ -12,7 +12,7 @@ const { t } = await getTranslations(Astro.currentLocale);
 const { lang, uuid } = Astro.params;
 
 const { instance } = await InstancesService.getFull(uuid);
-const excludes = config.search?.result_filtering?.instances?.exclude || [];
+const excludes = config.result_filtering?.instances?.exclude || [];
 
 const coverUrl = getCoverImage(instance);
 const geometry = getRelatedGeometry(instance);

--- a/src/pages/[lang]/items/[uuid]/index.astro
+++ b/src/pages/[lang]/items/[uuid]/index.astro
@@ -12,7 +12,7 @@ const { t } = await getTranslations(Astro.currentLocale);
 const { lang, uuid } = Astro.params;
 
 const { item } = await ItemsService.getFull(uuid);
-const excludes = config.search?.result_filtering?.items?.exclude || [];
+const excludes = config.result_filtering?.items?.exclude || [];
 
 const coverUrl = getCoverImage(item);
 const geometry = getRelatedGeometry(item);

--- a/src/pages/[lang]/organizations/[uuid]/index.astro
+++ b/src/pages/[lang]/organizations/[uuid]/index.astro
@@ -12,7 +12,7 @@ const { t } = await getTranslations(Astro.currentLocale);
 const { lang, uuid } = Astro.params;
 
 const { organization } = await OrganizationsService.getFull(uuid);
-const excludes = config.search?.result_filtering?.organizations?.exclude || [];
+const excludes = config.result_filtering?.organizations?.exclude || [];
 
 const coverUrl = getCoverImage(organization);
 const geometry = getRelatedGeometry(organization);

--- a/src/pages/[lang]/people/[uuid]/index.astro
+++ b/src/pages/[lang]/people/[uuid]/index.astro
@@ -13,7 +13,7 @@ const { t } = await getTranslations(Astro.currentLocale);
 const { lang, uuid } = Astro.params;
 
 const { person } = await PeopleService.getFull(uuid);
-const excludes = config.search?.result_filtering?.people?.exclude || [];
+const excludes = config.result_filtering?.people?.exclude || [];
 
 const coverUrl = getCoverImage(person);
 const geometry = getRelatedGeometry(person);

--- a/src/pages/[lang]/places/[uuid]/index.astro
+++ b/src/pages/[lang]/places/[uuid]/index.astro
@@ -12,7 +12,7 @@ const { t } = await getTranslations(Astro.currentLocale);
 const { lang, uuid } = Astro.params;
 
 const { place } = await PlacesService.getFull(uuid);
-const excludes = config.search?.result_filtering?.places?.exclude || [];
+const excludes = config.result_filtering?.places?.exclude || [];
 
 const coverUrl = getCoverImage(place);
 const geometry = place?.place_geometry?.geometry_json

--- a/src/pages/[lang]/works/[uuid]/index.astro
+++ b/src/pages/[lang]/works/[uuid]/index.astro
@@ -12,7 +12,7 @@ const { t } = await getTranslations(Astro.currentLocale);
 const { lang, uuid } = Astro.params;
 
 const { work } = await WorksService.getFull(uuid)
-const excludes = config.search?.result_filtering?.works?.exclude || []
+const excludes = config.result_filtering?.works?.exclude || []
 
 const coverUrl = getCoverImage(work);
 const geometry = getRelatedGeometry(work);


### PR DESCRIPTION
### In this PR
- Fixes a typo and updates language in the documentation to reflect that the `result_filtering` prop is not inside the `search` field of the config anymore.
- Updates the record detail pages to correctly look for `config.result_filtering` rather than `config.search.result_filtering`.
- Updates the `UserDefined.astro` component to actually respect the list of excluded UUIDs.
- (Unrelated but small fix) Fixed the header on `end_year` on the event detail pages (had been previously hard coded as `t('start_year')`.