### PR TITLE
Added handling for inverse facet labels

### DIFF
--- a/src/apps/search/Facet.tsx
+++ b/src/apps/search/Facet.tsx
@@ -1,23 +1,42 @@
 import TranslationContext from '@contexts/TranslationContext';
-import { Icon } from '@performant-software/core-data';
+import { Icon, useCachedHits } from '@performant-software/core-data';
 import { getFacetLabel } from '@utils/search';
 import clsx from 'clsx';
 import { useContext, useMemo, type ReactNode } from 'react';
+import _ from 'underscore';
 
 interface Props {
   attribute: string;
   children: ReactNode,
   className?: string;
   icon?: string;
+  inverse?: boolean;
 }
 
 const Facet = ({ attribute, children, className, icon }: Props) => {
   const { t } = useContext(TranslationContext);
 
+  //this is very janky but we need some way to determine whether to use the inverse label or not,
+  //and the easiest place to access that information seems to be by looking at the value of
+  //the attribute in a hit where it's defined
+
+  const hits = useCachedHits();
+
+  const attribute_base = useMemo(() => attribute.split('.')[0], [attribute]);
+
+  const sample_hit = useMemo(() => _.find(hits, (hit) => 
+    (hit && 
+      hit[attribute_base] && 
+      Array.isArray(hit[attribute_base]) && 
+      typeof hit[attribute_base][0] === 'object')
+    ), [hits, attribute_base]);
+
+  const inverse = useMemo(() => sample_hit && sample_hit[attribute_base][0]["inverse"], [sample_hit]);
+
   /**
    * Memo-izes the label for the current facet.
    */
-  const label = useMemo(() => getFacetLabel(attribute, t), [attribute, t]);
+  const label = useMemo(() => getFacetLabel(attribute, t, inverse), [attribute, t, inverse]);
 
   return (
     <div

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -46,15 +46,20 @@ export const getAttributes = (config) => config.result_card.attributes?.slice(0,
  *
  * @param attribute
  * @param t
+ * @param inverse
  */
-export const getFacetLabel = (attribute, t) => {
+export const getFacetLabel = (attribute, t, inverse = false, inverseSuffix = '_inverse') => {
   let value;
   
   // exclude these from facet labels, e.g. 'Organizations' rather than 'Organizations: Name'
   const DEFAULT_FIELDIDS = ["name", "names"]
 
-  const relationshipId = TypesenseUtils.getRelationshipId(attribute);
+  let relationshipId = TypesenseUtils.getRelationshipId(attribute);
   const fieldId = TypesenseUtils.getFieldId(attribute);
+
+  if (inverse) {
+    relationshipId = relationshipId + inverseSuffix;
+  }
 
   if (relationshipId && fieldId && !DEFAULT_FIELDIDS.includes(fieldId)) {
     value = t('facetLabel', { relationship: t(relationshipId), field: t(fieldId) })


### PR DESCRIPTION
### In this PR
Addresses Issue #266 in an extremely inelegant manner, by yoinking the first `hit` out of the `cachedHit` context that actually has a value for the passed attribute and checking whether it happens to be able to tell us the proper `inverse` flag value, and passing that to the method that finds the facet label so that it can append `_inverse` as required. Testing locally this seemed to get the job done, although I am in no way claiming this is the cleanest or best way to achieve the result.