### PR TITLE
Added check for whether `web_identifiers` is empty on detail page

### DIFF
--- a/src/apps/pages/RecordDetail/Identifiers.astro
+++ b/src/apps/pages/RecordDetail/Identifiers.astro
@@ -8,7 +8,7 @@ const { record } = Astro.props
 const lang = Astro.currentLocale;
 const { t } = await getTranslations(lang);
 ---
-{record.web_identifiers && (
+{record.web_identifiers && !_.isEmpty(record.web_identifiers) && (
   <>
     <div class="py-6">
         <h2 class="capitalize text-lg font-semibold">{t('webAuthorities')}</h2>


### PR DESCRIPTION
### In this PR
It is possible for the public API to return an empty array as the value of `web_identifiers` for a record; in this case we should not display the section on the record detail page at all, rather than display it with no content. This PR makes that fix.