### PR TITLE
Adding underline to image citation links

### DIFF
--- a/src/apps/pages/sections/Images.astro
+++ b/src/apps/pages/sections/Images.astro
@@ -25,7 +25,7 @@ const { items, title } = Astro.props;
       >
         <ImageWithCitation
           alt={item.image_alt}
-          classNames={{ root: 'w-full h-full', image: 'w-full h-full object-cover', citation: 'text-xs text-gray-400' }}
+          classNames={{ root: 'w-full h-full', image: 'w-full h-full object-cover', citation: `text-xs text-gray-400${item.citationLink ? ' underline' : ''}` }}
           src={item.image}
           citation={item.citation}
           citationLink={item.citation_link}

--- a/src/apps/pages/sections/TextImage.tsx
+++ b/src/apps/pages/sections/TextImage.tsx
@@ -176,7 +176,7 @@ const TextImage = (props: Props) => {
         >
           <ImageWithCitation
             alt={props.imageAlt}
-            classNames={{ image: 'w-full h-full object-cover', root: 'w-full h-full', citation: 'text-xs text-gray-400' }}
+            classNames={{ image: 'w-full h-full object-cover', root: 'w-full h-full', citation: `text-xs text-gray-400${props.citationLink ? ' underline' : ''}` }}
             src={props.image}
             citation={props.citation}
             citationLink={props.citationLink}


### PR DESCRIPTION
### In this PR
Adds `underline` class to the image citation text in the case that a citation link is provided.