### PR TITLE
Changing `getAll` method to fetch in batches of 10

### DIFF
--- a/src/services/coreData/base.ts
+++ b/src/services/coreData/base.ts
@@ -47,15 +47,13 @@ class Base {
       let pages = 1;
       for (let page = 1; page <= pages; page++ ) {
         try {
-          console.log(page)
           const response = await this.service.fetchAll(_.extend(REQUEST_PARAMS_GETALL, { page }));
           if (response.list?.pages > pages) {
             pages = response.list?.pages;
-            console.log(pages);
           }
           records = [...records, ...response[this.name]];
         } catch (error) {
-          console.log(page, error);
+          console.log(error);
         }
       }
     }


### PR DESCRIPTION
### In this PR
Updates the `getAll()` method of the FairData model services to use `per_page: 10` as the default rather than `per_page: 0` which tries to fetch all records in the model at once. This affects the performance of some of the Tina input components (for places and media) as well as some of the `getStaticPaths` functions for the static build, and should help avoid memory errors on the FairData backend for projects with a lot of data.