### PR TITLE
Add netlify caching headers for SSR optimizations

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,6 +17,15 @@ import '@styles/index.css';
 import 'swiper/css';
 import 'swiper/css/pagination';
 
+// Tell the browser to always check the freshness of the cache
+Astro.response.headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+
+// Tell Netlify's CDN to treat it as fresh for 5 minutes, then for up to a week return a stale version
+// while it revalidates. Use Durable Cache to minimize the need for serverless function calls.
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control", "public, durable, s-maxage=300, stale-while-revalidate=604800"
+);
+
 const branding = await fetchBranding();
 const { header, footer } = branding;
 


### PR DESCRIPTION
### In this PR
Adds headers to the `Layout` component to specify CDN caching behavior in order to optimize performance and minimize the number of serverless function calls, as discussed here: https://developers.netlify.com/guides/how-to-do-advanced-caching-and-isr-with-astro/

### Notes and questions
This seems like all upside as far as I can tell, and preliminary observations on NBU and Registro seem to me to make a real difference -- loading a person detail page on either of these goes from taking 3-5s on first load to taking under half a second when loaded shortly after in a private window, so it seems the CDN caching is doing something. I am very much not an expert in this aspect of development and of course I am open to suggestions or other ways to measure whether it's doing anything, or tweaks to these numbers (which I literally copy/pasted out of that Netlify guide article).