### PR TITLE
MapFeaturesContext: Architecture Concept

### DIFF
--- a/src/apps/search/map/MapFeaturesContext.tsx
+++ b/src/apps/search/map/MapFeaturesContext.tsx
@@ -1,0 +1,56 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { Feature, FeatureCollection } from '@peripleo/peripleo';
+import { Typesense, useCachedHits } from '@performant-software/core-data';
+import { useSearchConfig } from '../SearchConfigContext';
+
+interface MapFeaturesContextType {
+  places: FeatureCollection;
+  updatePlace(feature: Feature): void;
+}
+
+const MapFeaturesContext = createContext<MapFeaturesContextType>(null);
+
+interface Props {
+  children: ReactNode;
+}
+
+export const MapFeaturesContextProvider = ({ children }: Props) => {
+  const config = useSearchConfig();
+  const hits = useCachedHits();
+
+  // May have to be an empty feature collection instead!
+  const [places, setPlaces] = useState<FeatureCollection>(null);
+
+  /**
+   * Memo-izes the data to be displayed on the map as a feature collection.
+   */
+  useEffect(() => {
+    const options = config.map.cluster_radius ? { type: 'Point' } : undefined;
+    const featureCollection = Typesense.toFeatureCollection(hits, config.map.geometry, options);
+
+    // TODO we could make this smarter! If a feature with the given ID already exists,
+    // we could keep it. (Assuming that the hits would never provide a higher-res version than
+    // what we already have.)
+    setPlaces(featureCollection);
+  }, [hits]);
+
+  const updatePlace = (feature: Feature) => {
+    const updated = places.features.map(f => f.id === feature.id ? feature : f);
+    setPlaces({ type: 'FeatureCollection', features: updated });
+  }
+
+  return (
+    <MapFeaturesContext.Provider
+      value={{
+        places,
+        updatePlace
+      }}
+    >
+      { children }
+    </MapFeaturesContext.Provider>
+  )
+};
+
+export const useCachedPlaces = () => {
+  return useContext(MapFeaturesContext);
+}

--- a/src/apps/search/map/MapLayout.tsx
+++ b/src/apps/search/map/MapLayout.tsx
@@ -18,6 +18,7 @@ import {
 import PanelHistoryContext, { PanelHistoryEntryType } from './PanelHistoryContext';
 import GeosearchFilter from '@apps/search/map/GeosearchFilter';
 import { useSearchConfig } from '@apps/search/SearchConfigContext';
+import { MapFeaturesContextProvider } from './MapFeaturesContext';
 
 const DEFAULT_MAX_ZOOM = 14;
 
@@ -111,80 +112,82 @@ const MapLayout = () => {
 
   return (
     <PanelHistoryContext.Provider value={{panelHistory, setPanelHistory}}>
-      <div
-        className='absolute left-0 right-0 bottom-0 top-[64px]'
-      >
-        <MapView />
-      </div>
-      <Header
-        className='h-[64px]'
-        filters={filters}
-        onFiltersChange={setFilters}
-        onTimelineChange={setTimeline}
-        onViewChange={setView}
-        timeline={timeline}
-        view={view}
-        tableView={config.table}
-      />
-      <div
-        className='flex grow h-[calc(100vh-160px)]'
-      >
+      <MapFeaturesContextProvider>
         <div
-          className={clsx('flex', { 'grow': view === Views.list && !timeline })}
+          className='absolute left-0 right-0 bottom-0 top-[64px]'
+        >
+          <MapView />
+        </div>
+        <Header
+          className='h-[64px]'
+          filters={filters}
+          onFiltersChange={setFilters}
+          onTimelineChange={setTimeline}
+          onViewChange={setView}
+          timeline={timeline}
+          view={view}
+          tableView={config.table}
+        />
+        <div
+          className='flex grow h-[calc(100vh-160px)]'
         >
           <div
-            className='flex flex-col'
+            className={clsx('flex', { 'grow': view === Views.list && !timeline })}
           >
-            <Facets
-              className='w-[240px] px-6 bg-neutral-100 backdrop-blur-sm shadow-sm overflow-y-auto'
-              config={config}
-              open={filters}
-            >
-              <GeosearchFilter />
-            </Facets>
-          </div>
-          { view === Views.list && (
             <div
               className='flex flex-col'
             >
-              <ListView
-                className='w-[350px]'
+              <Facets
+                className='w-[240px] px-6 bg-neutral-100 backdrop-blur-sm shadow-sm overflow-y-auto'
+                config={config}
+                open={filters}
+              >
+                <GeosearchFilter />
+              </Facets>
+            </div>
+            { view === Views.list && (
+              <div
+                className='flex flex-col'
+              >
+                <ListView
+                  className='w-[350px]'
+                />
+              </div>
+            )}
+          </div>
+          { view === Views.table && (
+            <div
+              className='flex grow items-end'
+            >
+              <TableView
+                className='h-[350px]'
               />
             </div>
           )}
-        </div>
-        { view === Views.table && (
+          { timeline && (
+            <div
+              className='flex grow shrink max-w-full items-end'
+            >
+              <TimelineView
+                className={clsx(
+                  'h-[360px]',
+                  'flex',
+                  'grow',
+                  'shrink',
+                )}
+                padding={timelinePadding}
+              />
+            </div>
+          )}
           <div
-            className='flex grow items-end'
+            className='flex justify-end'
           >
-            <TableView
-              className='h-[350px]'
+            <SearchRoutes
+              className='w-[350px]'
             />
           </div>
-        )}
-        { timeline && (
-          <div
-            className='flex grow shrink max-w-full items-end'
-          >
-            <TimelineView
-              className={clsx(
-                'h-[360px]',
-                'flex',
-                'grow',
-                'shrink',
-              )}
-              padding={timelinePadding}
-            />
-          </div>
-        )}
-        <div
-          className='flex justify-end'
-        >
-          <SearchRoutes
-            className='w-[350px]'
-          />
         </div>
-      </div>
+      </MapFeaturesContextProvider>
     </PanelHistoryContext.Provider>
   );
 };

--- a/src/apps/search/map/MapView.tsx
+++ b/src/apps/search/map/MapView.tsx
@@ -3,17 +3,18 @@ import Tooltip from '@apps/search/map/Tooltip';
 import Map from '@components/Map';
 import {
   SearchResultsLayer,
-  Typesense as TypesenseUtils,
-  useCachedHits,
+  // Typesense as TypesenseUtils,
+  // useCachedHits,
   useGeoSearch,
   useSearching
 } from '@performant-software/core-data';
 import { HoverTooltip, useSelectionValue } from '@peripleo/maplibre';
-import { useCurrentRoute, useNavigate } from '@peripleo/peripleo';
+import { Feature, FeatureCollection, useCurrentRoute, useNavigate } from '@peripleo/peripleo';
 import { parseFeature } from '@utils/search';
-import { useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import _ from 'underscore';
 import { useSearchConfig } from '@apps/search/SearchConfigContext';
+import { useCachedPlaces } from './MapFeaturesContext';
 
 const MapView = () => {
   const config = useSearchConfig();
@@ -21,18 +22,20 @@ const MapView = () => {
   const navigate = useNavigate();
   const { selected } = useSelectionValue() || {};
   const route = useCurrentRoute();
-  const hits = useCachedHits();
+  // const hits = useCachedHits();
+  const places = useCachedPlaces();
   const searching  = useSearching();
 
   const { boundingBoxOptions, controlsClass } = useContext(MapSearchContext);
 
   /**
    * Memo-izes the data to be displayed on the map as a feature collection.
-   */
+   *
   const data = useMemo(() => {
     const options = config.map.cluster_radius ? { type: 'Point' } : undefined;
     return TypesenseUtils.toFeatureCollection(hits, config.map.geometry, options);
   }, [hits]);
+  */
 
   /**
    * If we're on the place detail page or refining results by the map view port, we'll suppress the auto-bounding box
@@ -79,7 +82,7 @@ const MapView = () => {
     >
       <SearchResultsLayer
         boundingBoxOptions={boundingBoxOptions}
-        data={data}
+        data={places}
         cluster={!!config.map.cluster_radius}
         clusterRadius={config.map.cluster_radius}
         fitBoundingBox={fitBoundingBox}

--- a/src/apps/search/map/panels/BasePanel.tsx
+++ b/src/apps/search/map/panels/BasePanel.tsx
@@ -26,7 +26,6 @@ import {
 import _ from 'underscore';
 import PanelHistoryContext from '@apps/search/map/PanelHistoryContext';
 import { useSearchConfig } from '@apps/search/SearchConfigContext';
-import { preProcessFile } from 'typescript';
 import { useCachedPlaces } from '../MapFeaturesContext';
 
 interface Props {

--- a/src/apps/search/map/panels/BasePanel.tsx
+++ b/src/apps/search/map/panels/BasePanel.tsx
@@ -26,6 +26,8 @@ import {
 import _ from 'underscore';
 import PanelHistoryContext from '@apps/search/map/PanelHistoryContext';
 import { useSearchConfig } from '@apps/search/SearchConfigContext';
+import { preProcessFile } from 'typescript';
+import { useCachedPlaces } from '../MapFeaturesContext';
 
 interface Props {
   className?: string;
@@ -49,6 +51,7 @@ const BasePanel = (props: Props) => {
 
   const navigate = useNavigate();
   const config = useSearchConfig();
+  const { updatePlace } = useCachedPlaces();
   const { t } = useContext(TranslationContext);
   const { setSelected } = useSelection();
 
@@ -209,7 +212,7 @@ const { data: { people = [] } = {}, loading: peopleLoading } = useLoader(onLoadP
   
   /**
    * Memo-izes the geometry.
-   */
+   *
   const geometry = useMemo(() => {
     if (props.resolveGeometry && item) {
       return props.resolveGeometry(item);
@@ -220,6 +223,19 @@ const { data: { people = [] } = {}, loading: peopleLoading } = useLoader(onLoadP
         places.filter((place) => place.place_geometry)
       );
   }, [item, places, props.resolveGeometry]);
+  */
+
+  useEffect(() => {
+    if (props.resolveGeometry && item) {
+      const highRes = props.resolveGeometry(item);
+      updatePlace(highRes);
+    } else if (!_.isEmpty(places.filter((place) => place.place_geometry))) {
+      const place = CoreDataUtils.toFeatureCollection(
+        places.filter((place) => place.place_geometry)
+      );
+      updatePlace(place);
+    }
+  }, [item, places, props.resolveGeometry])
   
   /**
    * Memo-izes the related media items.
@@ -450,7 +466,7 @@ const { data: { people = [] } = {}, loading: peopleLoading } = useLoader(onLoadP
           />
         )}
       </RecordDetailPanel>
-      { geometry && (
+      {/* geometry && (
         <LocationMarkers
           animate
           boundingBoxOptions={boundingBoxOptions}
@@ -465,7 +481,7 @@ const { data: { people = [] } = {}, loading: peopleLoading } = useLoader(onLoadP
           fitBoundingBox={_.get(config.map, 'zoom_to_place', true)}
           layerId='current'
         />
-      )}
+      ) */}
       { manifestUrl && (
         <MediaGallery
           manifestUrl={manifestUrl}


### PR DESCRIPTION
## In this PR

This is a **draft PR** that proposes centralizing all map-rendered geo-features into a shared, context-driven state. The goal is to maintain the current behavior (auto-populating the map from TypeSense hits) while enabling other components to update individual places at runtime (e.g. when the `BasePanel` fetches higher-resolution feature data).

#### Key Changes

- Introduced a new `MapFeaturesContext` that internally uses `useCachedHits` to derive a shared `places` state.
- Added a `useCachedPlaces` hook that exposes:
  - the current list of places
  - an `updatePlace` method for replacing an existing place with an updated (higher-res) version
- Wrapped the main interface in `MapFeaturesContextProvider` within `MapLayout`.
- Updated `MapView` to use  `useCachedPlaces` instead of `useCachedHits`.
- Removed the additional `LocationMarkers` in `BasePanel` that previously created duplicate overlays. Instead, `BasePanel` now updates the shared places state via `updatePlace`.

**IMPORTANT**: this is all conceptual and untested, since I'm lacking a proper setup (TypeSense access credentials, Tina backend etc.) Consider this a "pseudo-code-ish" proposal intended to illustrate the idea, and for further discussion.