### PR TITLE
Fixing some typography on search and detail pages

### DIFF
--- a/src/apps/pages/RecordDetail/Identifiers.astro
+++ b/src/apps/pages/RecordDetail/Identifiers.astro
@@ -11,7 +11,7 @@ const { t } = await getTranslations(lang);
 {record.web_identifiers && !_.isEmpty(record.web_identifiers) && (
   <>
     <div class="py-6">
-        <h2 class="capitalize text-lg font-semibold">{t('webAuthorities')}</h2>
+        <h4 class="capitalize italic">{t('webAuthorities')}</h4>
         <div class="text-neutral-800 break-words flex flex-col gap-2 pt-4">              
             { _.map(record.web_identifiers, (auth) => {
                 const url = getAuthorityURL(auth.web_authority?.source_type, auth.identifier);

--- a/src/apps/pages/RecordDetail/MediaContents.tsx
+++ b/src/apps/pages/RecordDetail/MediaContents.tsx
@@ -20,7 +20,7 @@ const MediaContents = (props: Props) => {
 
   return (
     <div className="py-6">
-      <h2 className="capitalize text-lg font-semibold mb-2">{t('relatedMedia', { count })}</h2>
+      <h4 className="capitalize italic mb-2">{t('relatedMedia', { count })}</h4>
       <div className='flex gap-6 flex-wrap'>
         {props.data.items && props.data.items.map(media => (
           <TranslationContext.Provider

--- a/src/apps/pages/RecordDetail/RelatedEvents.astro
+++ b/src/apps/pages/RecordDetail/RelatedEvents.astro
@@ -28,7 +28,7 @@ const showLinks = config.detail_pages?.models?.includes('events');
 ---
 {Object.keys(relationships).map((uuid) => (
   <div class='py-6 w-full'>
-    <h2 class='capitalize text-xl font-semibold font-header mb-2'>{t(uuid)}</h2>
+    <h4 class='capitalize italic mb-2'>{t(uuid)}</h4>
     <ul class='flex flex-col gap-4 list-disc ml-4'>
       {relationships[uuid].map((event) => (
         <li class='text-[22px] ml-2'>

--- a/src/apps/pages/RecordDetail/RelatedInstances.astro
+++ b/src/apps/pages/RecordDetail/RelatedInstances.astro
@@ -27,7 +27,7 @@ const showLinks = config.detail_pages?.models?.includes('instances');
 ---
 {Object.keys(relationships).map((uuid) => (
   <div class='py-6 w-full'>
-    <h2 class='capitalize text-xl font-semibold font-header mb-2'>{t(uuid)}</h2>
+    <h4 class='capitalize italic mb-2'>{t(uuid)}</h4>
     <div class='flex flex-col gap-4'>
       {relationships[uuid].map((instance) => (
         <>

--- a/src/apps/pages/RecordDetail/RelatedItems.astro
+++ b/src/apps/pages/RecordDetail/RelatedItems.astro
@@ -26,7 +26,7 @@ const showLinks = config.detail_pages?.models?.includes('items');
 ---
 {Object.keys(relationships).map((uuid) => (
   <div class='py-6 w-full'>
-    <h2 class='capitalize text-xl font-semibold font-header mb-2'>{t(uuid)}</h2>
+    <h4 class='capitalize italic mb-2'>{t(uuid)}</h4>
     <div class='flex flex-col gap-4'>
       {relationships[uuid].map((item) => (
         <>

--- a/src/apps/pages/RecordDetail/RelatedPlaces.astro
+++ b/src/apps/pages/RecordDetail/RelatedPlaces.astro
@@ -25,7 +25,7 @@ const resolveDetailUrl = (record: any) => `/${lang}/places/${record.uuid}`;
 ---
 {Object.keys(relationships).map((uuid) => (
   <div class='py-6 w-full'>
-    <h2 class='capitalize text-xl font-semibold font-header mb-2'>{t(uuid)}</h2>
+    <h4 class='capitalize italic mb-2'>{t(uuid)}</h4>
     <div class='grid grid-cols-[1fr_2fr] h-[300px] bg-white w-full gap-6'>
       <ul class='items-start justify-start font-body divide-y divide-neutral-200'>
         {relationships[uuid].map((place) =>

--- a/src/apps/pages/RecordDetail/RelatedWorks.astro
+++ b/src/apps/pages/RecordDetail/RelatedWorks.astro
@@ -26,7 +26,7 @@ const showLinks = config.detail_pages?.models?.includes('works');
 ---
 {Object.keys(relationships).map((uuid) => (
   <div class='py-6 w-full'>
-    <h2 class='capitalize text-xl font-semibold font-header mb-2'>{t(uuid)}</h2>
+    <h4 class='capitalize italic mb-2'>{t(uuid)}</h4>
     <div class='flex flex-col gap-4'>
       {relationships[uuid].map((work) => (
         <>

--- a/src/apps/pages/RecordDetail/Relations.astro
+++ b/src/apps/pages/RecordDetail/Relations.astro
@@ -15,7 +15,7 @@ const { data, icon, label, resolveDetailUrl, resolveName, showLinks } = Astro.pr
 ---
 {(Object.keys(data)).length > 0 && (
   <div class='py-6'>
-    <h2 class='capitalize text-xl font-semibold font-header mb-2'>{label}</h2>
+    <h4 class='capitalize italic font-header mb-2'>{label}</h4>
     <ul class='grid grid-cols-3 items-start justify-start font-body'>
       {data.map((record) =>
         showLinks && resolveDetailUrl ? (

--- a/src/apps/pages/RecordDetail/UserDefined.astro
+++ b/src/apps/pages/RecordDetail/UserDefined.astro
@@ -11,7 +11,7 @@ const { t } = await getTranslations(lang);
   <div class="grid grid-cols-2">
     {Object.keys(record.user_defined).map(uuid => (
       !excludes.includes(uuid) && <div class="py-6">
-        <h2 class="capitalize font-semibold font-body">{t(uuid)}</h2>
+        <h4 class="capitalize italic">{t(uuid)}</h4>
         <div class="text-neutral-800 break-words font-body">
           <UserDefinedFieldView
             type={record.user_defined[uuid].type}

--- a/src/apps/search/Facet.tsx
+++ b/src/apps/search/Facet.tsx
@@ -22,7 +22,7 @@ const Facet = ({attribute, children, className, icon}: Props) => {
     if (items.length > 0) {
       setLabel(getFacetLabel(attribute, t, isInverse(attribute, items)))
     }
-  }, [items.length]);
+  }, [items, attribute, t]);
 
   return (
     <div
@@ -34,7 +34,7 @@ const Facet = ({attribute, children, className, icon}: Props) => {
       )}
     >
       <h2
-        className='py-3 font-semibold flex items-center gap-1'
+        className='py-3 !font-bold flex items-center gap-1 !text-sm !font-sans uppercase'
       >
         { icon && (
           <Icon

--- a/src/apps/search/Facets.tsx
+++ b/src/apps/search/Facets.tsx
@@ -97,28 +97,32 @@ const Facets = (props: Props) => {
   }, [getFacetConfiguration]);
 
   return (
-    <aside
-      className={clsx(
-        { 'flex flex-col grow': props.open },
-        { 'hidden': !props.open },
-        props.className
-      )}
-    >
-      <div
-        className='flex justify-between items-center'
-      >
-        <h4
-          className='py-4 italic'
+    <>
+      { !!(sortedRangeAttributes?.length || sortedAttributes?.length) && (
+          <aside
+          className={clsx(
+            { 'flex flex-col grow': props.open },
+            { 'hidden': !props.open },
+            props.className
+          )}
         >
-          { t('filters') }
-        </h4>
-        <ClearRefinementsButton />
-      </div>
-      <CurrentRefinementsList />
-      { props.children }
-      { _.map(sortedRangeAttributes, (attribute) => renderFacet(attribute, TYPE_RANGE)) }
-      { _.map(sortedAttributes, (attribute) => renderFacet(attribute, TYPE_LIST)) }
-    </aside>
+          <div
+            className='flex justify-between items-center'
+          >
+            <h4
+              className='py-4 italic'
+            >
+              { t('filters') }
+            </h4>
+            <ClearRefinementsButton />
+          </div>
+          <CurrentRefinementsList />
+          { props.children }
+          { _.map(sortedRangeAttributes, (attribute) => renderFacet(attribute, TYPE_RANGE)) }
+          { _.map(sortedAttributes, (attribute) => renderFacet(attribute, TYPE_LIST)) }
+        </aside>
+      )}
+    </>
   );
 };
 

--- a/src/apps/search/Facets.tsx
+++ b/src/apps/search/Facets.tsx
@@ -107,11 +107,11 @@ const Facets = (props: Props) => {
       <div
         className='flex justify-between items-center'
       >
-        <h2
-          className='py-4 font-semibold text-lg'
+        <h4
+          className='py-4 italic'
         >
           { t('filters') }
-        </h2>
+        </h4>
         <ClearRefinementsButton />
       </div>
       <CurrentRefinementsList />

--- a/src/apps/search/map/panels/BasePanel.tsx
+++ b/src/apps/search/map/panels/BasePanel.tsx
@@ -412,6 +412,7 @@ const { data: { people = [] } = {}, loading: peopleLoading } = useLoader(onLoadP
   return (
     <aside
       className={clsx(
+        'detail-panel',
         'flex',
         'flex-col',
         'bg-white',

--- a/src/pages/[lang]/events/[uuid]/index.astro
+++ b/src/pages/[lang]/events/[uuid]/index.astro
@@ -31,7 +31,7 @@ export const getStaticPaths = async () => await getDetailPagePaths(ModelNames.ev
       if (event[field] && !excludes.includes(field)) {
         return (
           <div class='py-6'>
-            <h2 class='capitalize text-lg font-semibold'>{t(field)}</h2>
+            <h4 class='capitalize italic'>{t(field)}</h4>
             <div class='text-neutral-800'>
               <p>{FuzzyDateUtils.getDateView(event[field])}</p>
             </div>

--- a/src/pages/[lang]/search/[name]/index.astro
+++ b/src/pages/[lang]/search/[name]/index.astro
@@ -25,7 +25,7 @@ export const getStaticPaths = () => {
 
 const searchConfig = config.search.find((s) => s.name === name) as SearchConfig;
 
-const isListSearch = !!searchConfig.type && searchConfig.type !== 'map';
+const isListSearch = !!searchConfig?.type && searchConfig?.type !== 'map';
 ---
 
 <Layout

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -170,6 +170,14 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--color-text-secondary) !important;
 }
 
+.banner-header {
+  font-variant: var(--Font-Variant-banner-header);
+}
+
+.detail-panel h1 {
+  font-size: var(--Font-Sizes-h4);
+}
+
 /*
  * Swiper styles
  */

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -204,7 +204,8 @@ describe('search', () => {
       test('type matches allowed values', () => {
         const types = [
           'list',
-          'select'
+          'select',
+          'range'
         ];
 
         expect(facet.type).toBeOneOf(types);


### PR DESCRIPTION
### In this PR
Fixes some spillover from the general typography updates that was affecting header elements in the search and detail pages. Also updates some typography to match the current designs, and adds the ability to specify `range` as the type of facet.

### Notes
These were quick fixes in order to make the JUEL sites presentable in last week's meeting; possibly these changes will be made redundant by upcoming work on the search and detail page styling QA more generally, so we might want to hold off on merging this until that work is done, if at all.