### PR TITLE
Fixing case of `0` showing up below banner

### DIFF
--- a/src/apps/pages/sections/Banner.astro
+++ b/src/apps/pages/sections/Banner.astro
@@ -63,7 +63,7 @@ const {
       class='absolute top-0 left-0 w-full h-full bg-tertiary mix-blend-multiply'
     /> 
   ) }
-  { (title || subtitle || url || content?.children?.length) && (
+  { !!(title || subtitle || url || content?.children?.length) && (
     <Container className={clsx(
       'flex flex-col w-full overflow-hidden',
       { 'items-center text-center': textAlignment === 'center' },


### PR DESCRIPTION
### In this PR
Addresses Issue #412 by double-negating the condition on rendering content so that it will always return as `false` (when it's false) rather than `0`.