### PR TITLE
CDP #374 - Footer buttons

### DIFF
--- a/src/components/LinkButton.tsx
+++ b/src/components/LinkButton.tsx
@@ -9,33 +9,47 @@ interface Props {
   color?: string;
   content: JSX.Element | string;
   href: string;
+  target?: string;
   text?: string;
 }
 
-const LinkButton = ({ className, content, href, ...props }: Props) => (
-  <a
-    className={clsx(
-      'link-button inline-flex mt-4 rounded-md hover:bg-opacity-95 cursor-pointer flex-row gap-4 items-center no-underline',
-      { 'px-6 py-3 hover:bg-[linear-gradient(rgba(0,0,0,0.15),rgba(0,0,0,0.15))] transition duration-300': props.color || props.border },
-      'focus:outline-none',
-      props.color && 'focus:shadow-[0_1px_2px_0_rgba(0,0,0,0.05),0_0_0_2px_var(--color-layout),0_0_0_4px_var(--color-secondary)]',
-      { 'hover:underline hover:underline-offset-[6px] hover:decoration-2': !props.color && !props.border },
-      { 'hover:no-underline': props.color || props.border },
-      toBackgroundClass(props.color),
-      props.text && toTextClass(props.text),
-      toBorderClass(props.border),
-      className
-    )}
-    href={href}
-    {...props}
-  >
-    <div>
+const LinkButton = (props: Props) => {
+  const {
+    arrow,
+    border,
+    color,
+    className,
+    content,
+    href,
+    text,
+    ...rest
+  } = props;
+
+  return (
+    <a
+      className={clsx(
+        'link-button inline-flex mt-4 rounded-md hover:bg-opacity-95 cursor-pointer flex-row gap-4 items-center no-underline',
+        'px-6 py-3 hover:bg-[linear-gradient(rgba(0,0,0,0.15),rgba(0,0,0,0.15))] transition duration-300 focus:outline-none hover:no-underline',
+        { 'focus:shadow-[0_1px_2px_0_rgba(0,0,0,0.05),0_0_0_2px_var(--color-layout),0_0_0_4px_var(--color-secondary)]': color },
+        toTextClass(text),
+        toBackgroundClass(color),
+        toBorderClass(border),
+        className
+      )}
+      href={href}
+      {...rest}
+    >
       { content }
-    </div>
-    { props.arrow && ( 
-      <ArrowRightIcon height={24} width={24} />
-    ) }
-  </a>
-);
+      { arrow && (
+        <ArrowRightIcon
+          height={24}
+          width={24}
+        />
+      ) }
+    </a>
+  );
+};
+
+
 
 export default LinkButton;

--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -1,12 +1,12 @@
 ---
 import Container from '@components/Container.astro';
 import LinkButton from '@components/LinkButton';
+import MultiColumnContent from '@components/MultiColumnContent.astro';
 import config from '@config';
 import NavBar from '@layouts/NavBar.astro';
+import { toBackgroundClass } from '@utils/pageBuilder';
 import clsx from 'clsx';
 import _ from 'underscore';
-import { toBackgroundClass, toTextClass } from '@utils/pageBuilder';
-import MultiColumnContent from '@components/MultiColumnContent.astro';
 
 const {
   accessibilityUrl,
@@ -78,13 +78,13 @@ const year = new Date().getFullYear();
           class='flex flex-col lg:flex-row lg:w-full lg:justify-center gap-y-4 pb-12'
         >
           <LinkButton
-            className='bg-secondary w-[200px] text-center'
+            className='bg-secondary w-[200px] justify-center'
             content={t('coreDataLogin')}
             href={config.core_data.url}
             target='_blank'
           />
           <LinkButton
-            className='bg-secondary w-[200px] text-center'
+            className='bg-secondary w-[200px] justify-center'
             content={t('tinaLogin')}
             href='/admin/index.html'
             target='_blank'


### PR DESCRIPTION
This pull request fixes the issues with the `LinkButton` components in the footer presented in #374.

**Disclaimer:** This seems to have broken some of the places where this component is used as a link without padding and with underline text decoration. I would argue that the purpose of this component is to format a `<a>` tag as a button, so perhaps we need a separate component for when we want to render a more traditional link?

<img width="752" height="398" alt="Screenshot 2026-01-16 at 6 49 34 AM" src="https://github.com/user-attachments/assets/6c6adf38-9ec3-4bdd-b889-6813e21c287c" />
<img width="699" height="392" alt="Screenshot 2026-01-16 at 6 50 07 AM" src="https://github.com/user-attachments/assets/0583e141-38c0-4bd4-8e71-524f871e494a" />