### PR TITLE
CDP #366 - Tab headers

### DIFF
--- a/src/apps/pages/sections/Tabs.tsx
+++ b/src/apps/pages/sections/Tabs.tsx
@@ -31,13 +31,18 @@ const Tabs = (props: TabsProps) => {
 
   return (
     <TabGroup>
-      <div className={clsx(
-        'px-6 sm:px-12 md:px-16 lg:px-32 2xl:mx-auto max-w-(--breakpoint-2xl)',
-      )}>
-        <TabList aria-label='Tabs' className={clsx(
-          '-mb-px flex h-[65px] overflow-x-auto relative z-30',       
-          { 'border-b-2': !raise }
-        )}>
+      <div
+        className={clsx(
+          'px-6 sm:px-12 md:px-16 lg:px-32 2xl:mx-auto max-w-(--breakpoint-2xl)',
+        )}
+      >
+        <TabList
+          aria-label='Tabs'
+          className={clsx(
+            '-mb-px flex h-[65px] relative z-30',
+            { 'border-b-2': !raise }
+          )}
+        >
           {
             _.map(tabs, (tab) => ( 
               <Tab


### PR DESCRIPTION
This pull request fixes an issue with the Tabs section where the tab headers were displaying with a scrollbar.

<img width="1157" height="867" alt="Screenshot 2026-01-16 at 9 37 21 AM" src="https://github.com/user-attachments/assets/ed592b68-d72a-4d0c-8012-19fb9422796e" />

