### PR TITLE
List search QA feedback

### DIFF
--- a/src/apps/search/list/Hits.tsx
+++ b/src/apps/search/list/Hits.tsx
@@ -124,26 +124,32 @@ const Hits = (props: Props) => {
       <HitComponent
         highlightComponent={Highlight}
         key={item.hit.id}
+        labels={{
+          tags: t('tags')
+        }}
         {...item}
       />
     );
 
     if (isLinkable) {
       return (
-        <a href={`/${props.lang}${searchConfig.route}/${item.hit.id}`}>
-          {hitComp}
+        <a
+          href={`/${props.lang}${searchConfig.route}/${item.hit.id}`}
+          key={item.hit.id}
+        >
+          { hitComp }
         </a>
       );
     }
 
     return hitComp
-  }, [isLinkable, searchConfig.route, props.lang]);
+  }, [isLinkable, searchConfig.route, props.lang, t]);
 
   return (
     <div
       className={clsx(
-        'gap-4 py-6',
-        {'w-full grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 py-4': isGrid},
+        'gap-4 pb-6',
+        {'w-full grid md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4': isGrid},
         {'flex flex-col': !isGrid}
       )}>
         { hits.map((hit) => renderItem(hit)) }

--- a/src/apps/search/list/ListLayout.tsx
+++ b/src/apps/search/list/ListLayout.tsx
@@ -18,13 +18,13 @@ const ListLayout = (props: Props) => {
   const { t } = useContext(TranslationContext);
 
   return (
-    <div className='md:px-8'>
-      <div className='w-full flex justify-between items-center flex-wrap border-b border-neutral-200'>
+    <div className='px-6 md:px-8 lg:px-12'>
+      <div className='w-full py-4 gap-4 flex justify-between items-center flex-wrap border-b border-neutral-200'>
         <h2>{t(`index_${config.name}`)}</h2>
         <SearchBox
           placeholder={t('search')}
           classNames={{
-            root: 'p-4 w-full max-w-[720px]',
+            root: 'w-full max-w-[720px]',
             form: 'relative',
             input: 'rounded-[5px] border border-neutral-200 bg-white py-2 pl-12 pr-10 text-md w-full placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500',
             submit: 'absolute inset-y-4 left-4 flex items-center',
@@ -36,16 +36,16 @@ const ListLayout = (props: Props) => {
           }}
         />
       </div>
-      <div className='flex'>
-        <div className='w-[300px]'>
+      <div className='flex gap-x-8 lg:gap-x-12'>
+        <div className='w-[200px] xl:w-[300px]'>
           <Facets
             className='py-0'
             config={config}
             open
           />
         </div>
-        <div className='flex-1 p-6'>
-          <div className='flex justify-between items-center mb-4'>
+        <div className='flex-1 pb-6'>
+          <div className='flex justify-between items-center py-5'>
             <Stats />
             <SortBy />
           </div>

--- a/src/components/custom/default/GridHit.tsx
+++ b/src/components/custom/default/GridHit.tsx
@@ -10,7 +10,7 @@ const GridHit = (props: HitComponentProps) => {
   );
 
   return (
-    <div className='bg-white rounded-md shadow-md overflow-hidden flex flex-col divide-zinc-200 divide-y h-full'>
+    <div className='bg-white rounded-md shadow-xs hover:shadow-md overflow-hidden flex flex-col divide-zinc-200 divide-y h-full'>
       {props.hit.thumbnail && (
         <img
           alt={props.hit.name}

--- a/src/components/custom/default/ImageHit.tsx
+++ b/src/components/custom/default/ImageHit.tsx
@@ -3,7 +3,7 @@ import { HitComponentProps } from '@types';
 
 const ImageHit = (props: HitComponentProps) => {
   return (
-    <div className='bg-white rounded-md shadow-md overflow-hidden flex flex-col divide-zinc-200 divide-y h-auto'>
+    <div className='bg-white rounded-md shadow-xs hover:shadow-md overflow-hidden flex flex-col divide-zinc-200 divide-y h-auto'>
       {props.hit.thumbnail && (
         <img
           alt={props.hit.name}

--- a/src/components/custom/default/ListHit.tsx
+++ b/src/components/custom/default/ListHit.tsx
@@ -3,53 +3,66 @@ import { useMemo } from 'react';
 import { Pill } from '@performant-software/core-data/ssr';
 import { HitComponentProps } from '@types';
 
-const ListHit = (props: HitComponentProps) => {
+interface Props extends HitComponentProps {
+  labels: {
+    tags: string
+  }
+}
+
+const ListHit = (props: Props) => {
   const relationshipUuids = useMemo(
     () => Object.keys(props.relationships),
     [props.relationships]
   );
 
   return (
-    <div className='flex gap-x-6 p-4 bg-white rounded-md shadow-md'>
+    <div className='flex gap-x-6 p-4 bg-white rounded-md shadow-xs hover:shadow-md'>
       <div className='flex flex-col grow divide-y divide-zinc-900/20'>
-        <div>
-          <div>
-            {props.tags?.map(tg => (
-              <Pill
-                primary={tg.primary}
-                secondary={tg.secondary}
-                key={tg.name}
-                label={tg.value}
-                className='text-xs rounded-[5px]! p-0.5!'
-              />
-            ))}
-          </div>
+        <div className='pb-2'>
           {props.highlightComponent
             ? <props.highlightComponent hit={props.hit} className='font-bold text-neutral-950' attribute='name'/>
             : <p className='font-bold text-neutral-950'>{props.hit.name}</p>
           }
         </div>
-        {props.attributes.length > 0 && (
-          <ul className='grid grid-cols-4 w-full'>
-            {props.attributes.map(att => (
-              <li
-                className='flex flex-col gap-2 py-2'
-                key={att.name}
-              >
-                <p className='uppercase text-black/50 text-xs'>{att.label}</p>
-                {props.highlightComponent
-                  ? <props.highlightComponent className='font-semibold text-sm' hit={props.hit} attribute={att.name}/>
-                  : <span className='font-semibold text-sm'>{att.value}</span>
-                }
+        {(props.attributes.length > 0 || props.tags.length > 0) && (
+          <div className='py-2'>
+            {props.attributes.length > 0 && (
+              <ul className='grid grid-cols-4 w-full'>
+                {props.attributes.map(att => (
+                  <li
+                    className='flex gap-2 items-center'
+                    key={att.name}
+                  >
+                    <p className='uppercase text-black/50 text-xs font-semibold'>{att.label}</p>
+                    {props.highlightComponent
+                      ? <props.highlightComponent className='font-semibold text-sm' hit={props.hit} attribute={att.name}/>
+                      : <span className='font-semibold text-sm'>{att.value}</span>
+                    }
+                  </li>
+                ))}
+              </ul>
+            )}
+            {props.tags.length > 0 && (
+              <li className='flex items-center gap-2 w-full'>
+                <span className="text-xs font-semibold text-black/50 uppercase">{props.labels.tags}</span>
+                {props.tags?.map(tg => (
+                  <Pill
+                    primary={tg.primary}
+                    secondary={tg.secondary}
+                    key={tg.name}
+                    label={tg.value}
+                    className='text-xs rounded-[5px]! px-2! py-1!'
+                  />
+                ))}
               </li>
-            ))}
-          </ul>
+            )}
+          </div>
         )}
         {relationshipUuids.length > 0 && (
-          <ul className='grid grid-cols-4 w-full'>
+          <ul className='grid grid-cols-4 w-full pt-2'>
             {relationshipUuids.map(uuid => (
               <li
-                className='flex items-center gap-2 py-2 text-[13px]'
+                className='flex items-center gap-2 text-[13px]'
                 key={uuid}
               >
                 <span className='italic'>{props.relationships[uuid].label}</span>
@@ -61,6 +74,7 @@ const ListHit = (props: HitComponentProps) => {
       </div>
       {props.hit.thumbnail && (
         <img
+          alt={props.hit.name}
           className='object-cover w-[140px] h-[115px]'
           src={props.hit.thumbnail}
         />
@@ -78,6 +92,9 @@ ListHit.propTypes = {
   })),
   highlightComponent: PropTypes.func,
   hit: PropTypes.object,
+  labels: PropTypes.shape({
+    tags: PropTypes.string.isRequired
+  }),
   tags: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string,
     primary: PropTypes.bool,

--- a/src/i18n/i18n.json
+++ b/src/i18n/i18n.json
@@ -478,5 +478,9 @@
   "contactFormSubmitted.content": {
     "tinaLabel": "Contact Form Submitted > Content",
     "defaultValue": "We appreciate you contacting us. One of our colleagues will get back in touch with you soon! Have a great day!"
+  },
+  "tags": {
+    "tinaLabel": "Tags",
+    "defaultValue": "Tags"
   }
 }


### PR DESCRIPTION
# Summary

This PR addresses Chelsea's feedback for the list search page. It includes a bunch of changes to padding, etc., as well as a significant redesign of the list search cards. I also fixed a console warning about a missing `key` prop for the link wrapper that goes around linkable hits.

## Screenshot

Since the JUEL CDP config doesn't have attributes or tags defined yet, I picked some fields at random.

<img width="1473" height="742" alt="Screenshot 2026-01-20 at 5 21 31 PM" src="https://github.com/user-attachments/assets/52969d7e-7da2-4b5c-91b2-a67cfe0b259c" />
