### PR TITLE
Update `tabs` section schema to use common fields

### DIFF
--- a/tina/content/pages.ts
+++ b/tina/content/pages.ts
@@ -954,12 +954,7 @@ const Pages: Collection = {
           return { label: getLabel('Tabbed Content', item?.id) };
         }
       },
-      fields: [{
-        name: 'raise',
-        label: 'Overlap with section above?',
-        description: 'Select this option to create the visual effect of tabs jutting up into the previous section, e.g. a hero.',
-        type: 'boolean'
-      }, {
+      fields: [...commonSectionFields, {
         name: 'invert_text',
         label: 'Default to light text color for tabs with no specified background color?',
         description: 'For tabs that overlap with the section above, select this option if the section above has a dark background.',


### PR DESCRIPTION
### In this PR
From my notes this should have been part of PR #391 but it must have gotten bulldozed over somehow in resolving merge conflicts. The `Tabs` section should use the same common fields as all the other sections.