### PR TITLE
Apply font size and padding tweaks to linksbanner

### DIFF
--- a/src/apps/pages/sections/LinksBanner.astro
+++ b/src/apps/pages/sections/LinksBanner.astro
@@ -15,7 +15,7 @@ const { linkBackground, links, overlap } = Astro.props;
       {
         _.map(links, link => ( 
           <a href={link.url || '#'} class={clsx(
-            'hero-tab flex items-center justify-center py-8 px-12 font-serif italic text-2xl z-50 h-[80px]',
+            'hero-tab flex items-center text-center justify-center py-8 px-2 md:px-4 lg:px-8 font-serif italic text-lg md:text-2xl z-50 h-[80px]',
             'hover:bg-[linear-gradient(rgba(0,0,0,0.15),rgba(0,0,0,0.15))] transition duration-300',
             toBackgroundClass(linkBackground)
           )}>


### PR DESCRIPTION
### In this PR
As per Figma comments, updates the `LinksBanner` section component to look better on small screens. Resolves #442 .

BEFORE
<img width="613" height="269" alt="image" src="https://github.com/user-attachments/assets/055a23bf-7426-4034-85e6-1947b9aff960" />

AFTER 
<img width="632" height="287" alt="image" src="https://github.com/user-attachments/assets/a54d6309-8407-4b65-a12d-a86cc89001a7" />
