### PR TITLE
Specify spacer height rather than margin

### DIFF
--- a/src/components/Spacer.tsx
+++ b/src/components/Spacer.tsx
@@ -10,16 +10,22 @@ interface SpacerProps {
 const Spacer = (props: SpacerProps) => (
   <div
     className={clsx(
+      'w-full flex items-center',
+      { 'h-[1px]': props.size === 'none' && !props.thick },
+      { 'h-[2px]': props.size === 'none' && props.thick },
+      { 'h-3 lg:h-5': props.size === 'xs'},
+      { 'h-4 lg:h-8': props.size === 'small' },
+      { 'h-8 lg:h-16': props.size === 'medium' },
+      { 'h-16 lg:h-24': props.size === 'large' },
+    )}
+    >
+    <div className={clsx(
       'w-full',
       { 'h-[1px]': !!props.color && !props.thick },
       { 'h-[2px]': !!props.color && props.thick },
-      { 'my-3 lg:my-5': props.size === 'xs'},
-      { 'my-4 lg:my-8': props.size === 'small' },
-      { 'my-8 lg:my-16': props.size === 'medium' },
-      { 'my-16 lg:my-24': props.size === 'large' },
       toBackgroundClass(props.color)
-    )}
-  />
+    )} />
+  </div>
 );
 
 export default Spacer;


### PR DESCRIPTION
### In this PR
As was pointed out in QA, we had been using vertical margin to create the desired height for the `Spacer` component, but this leads to the wrong height when a divider line is actually present. Actually specifying the height explicitly ensures each spacer size will always be the right size.

Resolves #446 .