### PR TITLE
Fixing issues with tab borders

### DIFF
--- a/src/apps/pages/sections/Tabs.tsx
+++ b/src/apps/pages/sections/Tabs.tsx
@@ -32,11 +32,11 @@ const Tabs = (props: TabsProps) => {
   return (
     <TabGroup>
       <div className={clsx(
-        'px-6 sm:px-12 md:px-16 lg:px-32 2xl:mx-auto max-w-(--breakpoint-2xl)',
+        'px-6 sm:px-12 md:px-16 lg:px-32 2xl:mx-auto max-w-(--breakpoint-2xl) overflow-x-auto overflow-y-visible',
       )}>
         <TabList aria-label='Tabs' className={clsx(
-          '-mb-px flex h-[65px] overflow-x-auto relative z-30',       
-          { 'border-b-2': !raise }
+          'flex min-h-[65px] relative z-30',       
+          { 'w-full border-b-4 h-[65px]': !raise }
         )}>
           {
             _.map(tabs, (tab) => ( 
@@ -47,12 +47,12 @@ const Tabs = (props: TabsProps) => {
                 {({ hover, selected }) => ( 
                   <button className={clsx(
                     'lg:whitespace-nowrap px-3 lg:px-6 xl:px-8 py-4 focus:outline-none',
-                    { '-mb-[2px] border-b-2': !raise },
+                    { '-mb-[4px] border-b-4': !raise },
                     selected && activeBgClass,
                     !selected && inactiveBgClass,
                     (!selected || !activeBgClass) && raise && invertText && 'text-text-inverse',
-                    { 'border-secondary/60 border-b-2 text-secondary/60': hover && !raise },
-                    { 'border-secondary border-b-2 text-secondary': selected && !raise },
+                    { 'border-secondary/60 border-b-4 text-secondary/60': hover && !raise },
+                    { 'border-secondary border-b-4 text-secondary': selected && !raise },
                     { 'cursor-default': selected },
                     { 'font-serif italic sm:text-lg lg:text-xl font-normal': textStyle === 'italic' },
                     { 'text-sm text-gray-500 uppercase font-medium': textStyle === 'uppercase' }


### PR DESCRIPTION
### In this PR
Resolves #443 by tweaking the border widths and margins in the `Tabs` section component to eliminate the vertical scroll that hid the colored borders on selected tabs.

BEFORE
<img width="827" height="490" alt="image" src="https://github.com/user-attachments/assets/364b664d-86b9-46ad-a059-8ae888db518c" />


AFTER
<img width="805" height="575" alt="image" src="https://github.com/user-attachments/assets/8ac26679-d7e0-4e57-a30e-6e873058be89" />
