### PR TITLE
Relabel `multicolumn` to `columns`

### DIFF
--- a/tina/content/pages.ts
+++ b/tina/content/pages.ts
@@ -323,10 +323,10 @@ const staticSectionTemplates: Template<false>[] = [{
   }]
 }, {
   name: 'multi_column',
-  label: 'Multi Columns',
+  label: 'Columns',
   ui: {
     itemProps: (item) => {
-      return { label: getLabel('Multi-column', item?.id || item?.title) };
+      return { label: getLabel('Columns', item?.id || item?.title) };
     }
   },
   fields: [...commonSectionFields, {


### PR DESCRIPTION
### In this PR
It was a bit confusing for the section to be labeled `Multicolumn` in Tina when there are some use cases where you might want to use only a single column; the label `Columns` feels more broad and intuitive. Resolves #436 .