### PR TITLE
Improved handling for external navbar links

### DIFF
--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,4 +1,5 @@
 import NavItem from '@components/NavItem';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid';
 
 interface Props {
   active?: boolean;
@@ -6,16 +7,28 @@ interface Props {
   href: string
 }
 
-const NavLink = ({ active, content, href }: Props) => (
-  <a
-    className='flex flex-col p-y-4 justify-center'
-    href={href}
-  >
-    <NavItem
-      active={active}
-      content={content}
-    />
-  </a>
-);
+const NavLink = ({ active, content, href }: Props) => {
+  const isInternalLink = href.startsWith('/');
+
+  return (
+    <a
+      className='flex p-y-4 justify-center gap-2 items-center'
+      href={href}
+      target={isInternalLink ? '_self' : '_blank'}
+      rel={isInternalLink ? 'noopener noreferrer' : undefined}
+    >
+      <NavItem
+        active={active}
+        content={content}
+      />
+      {!isInternalLink && (
+        <ArrowTopRightOnSquareIcon
+          height={16}
+          width={16}
+        />
+      )}
+    </a>
+  )
+};
 
 export default NavLink;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -64,7 +64,7 @@ const lang = getLanguageFromUrl(Astro.url.pathname);
 
 const pages = await getPages(currentLocale);
 
-const { footer: includeFooter, fullscreen, name, title, t, tab, transparent } = Astro.props;
+const { footer: includeFooter, fullscreen, title, t, tab, transparent } = Astro.props;
 
 const getNavItems = async () => {
   const tinaNavbar = await fetchNavbar(currentLocale);


### PR DESCRIPTION
# Summary

This PR improves the handling of external navbar links:

* updates the description of the Tina field to make it clearer to users that they should use relative paths for internal links
* updates `NavLink` to open external links in a new tab and render with an icon that indicates this 

## Screenshots

<img width="354" height="62" alt="Screenshot 2026-01-27 at 5 26 15 PM" src="https://github.com/user-attachments/assets/bebc810b-b184-496e-95a5-98390b6d7a13" />
<img width="516" height="104" alt="Screenshot 2026-01-27 at 5 27 03 PM" src="https://github.com/user-attachments/assets/8c59ee29-75f7-4ea8-a6cd-eb4309b31948" />
