### PR TITLE
Fixing `search.type` and `search.facet.type` fields

### DIFF
--- a/tina/content/settings.ts
+++ b/tina/content/settings.ts
@@ -187,6 +187,23 @@ const Settings: Collection = {
       type: 'string',
       required: true
     }, {
+      name: 'type',
+      label: 'Type',
+      type: 'string',
+      options: [{
+        label: 'Map',
+        value: 'map'
+      }, {
+        label: 'List',
+        value: 'list'
+      }, {
+        label: 'Grid',
+        value: 'grid'
+      }, {
+        label: 'Image',
+        value: 'image'
+      }]
+    }, {
       name: 'geosearch',
       label: 'Geo-search',
       type: 'boolean'
@@ -213,7 +230,6 @@ const Settings: Collection = {
         name: 'type',
         label: 'Type',
         type: 'string',
-        list: true,
         options: [{
           value: 'list',
           label: 'List',
@@ -267,11 +283,11 @@ const Settings: Collection = {
           label: 'Icon',
           type: 'string'
         }]
-      }, {
-    name: 'table',
-    label: 'Table results view?',
-    type: 'boolean'
-  }]
+      }]
+    }, {
+      name: 'table',
+      label: 'Table results view?',
+      type: 'boolean'
     }, {
       name: 'timeline',
       label: 'Timeline',


### PR DESCRIPTION
### In this PR
Some cleanup of the `settings` collection schema in Tina to match the schema expected by the code and the testing suite. Specifically:
- Removes `list: true` from `search.facets.type` -- this was causing Tina to save values as e.g.
```
{
  name: 'whatever_facet',
  type: [
    "select"
  ]
}
```
which then causes builds of the site to fail.
- Adds the `search.type` field as specified in the README; previously this field could get removed entirely after editing the config in Tina, again causing the build to fail if there are searches with no specified type and also no `map` properties given.
- Moves the `search.table` field out from inside `search.result_card`.

### Notes
It appears that the entire `detail_pages` schema is missing from Tina, but I haven't noticed that causing specific issues; but unless there's some reason to exclude it that I'm not thinking of it should probably be added too, either here or in a separate issue.