### PR TITLE
Adding clover viewer to image search

### DIFF
--- a/src/apps/search/list/Hits.tsx
+++ b/src/apps/search/list/Hits.tsx
@@ -4,8 +4,9 @@ import ImageHit from '@components/custom/project/ImageHit'
 import ListHit from '@components/custom/project/ListHit'
 import { useSearchConfig } from '@apps/search/SearchConfigContext';
 import { Highlight } from 'react-instantsearch';
-import { useCallback, useContext, useMemo, useRef } from 'react';
+import { useCallback, useContext, useMemo, useRef, useState } from 'react';
 import { getAttributes, getFacetLabel, getHitValue, getRelationshipLabel, isInverse } from '@utils/search';
+import { MediaGallery } from '@performant-software/core-data';
 import clsx from 'clsx';
 import TranslationContext from '@contexts/TranslationContext';
 import { hasDetailPage } from '@utils/detailPagePaths';
@@ -25,6 +26,7 @@ const Hits = (props: Props) => {
   const searchConfig = useSearchConfig();
   const { items } = useHits();
   const { t } = useContext(TranslationContext);
+  const [manifestUrl, setManifestUrl] = useState<string | null>(null);
 
   const isGrid = useMemo(() => searchConfig.type !== 'list', [searchConfig.type]);
 
@@ -130,6 +132,7 @@ const Hits = (props: Props) => {
         labels={{
           tags: t('tags')
         }}
+        setManifestUrl={setManifestUrl}
         {...item}
       />
     );
@@ -149,14 +152,22 @@ const Hits = (props: Props) => {
   }, [isLinkable, searchConfig.route, props.lang, t]);
 
   return (
-    <div
-      className={clsx(
-        'gap-4 pb-6',
-        {'w-full grid md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4': isGrid},
-        {'flex flex-col': !isGrid}
-      )}>
-        { hits.map((hit) => renderItem(hit)) }
-    </div>
+    <>
+      <div
+        className={clsx(
+          'gap-4 pb-6',
+          {'w-full grid md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4': isGrid},
+          {'flex flex-col': !isGrid}
+        )}>
+          { hits.map((hit) => renderItem(hit)) }
+      </div>
+      { manifestUrl && (
+        <MediaGallery
+          manifestUrl={manifestUrl}
+          onClose={() => setManifestUrl(null)}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/components/custom/default/ImageHit.tsx
+++ b/src/components/custom/default/ImageHit.tsx
@@ -1,13 +1,21 @@
 import PropTypes from 'prop-types';
 import { HitComponentProps } from '@types';
+import clsx from 'clsx';
 
 const ImageHit = (props: HitComponentProps) => {
   return (
-    <div className='bg-white rounded-md shadow-xs hover:shadow-md overflow-hidden flex flex-col divide-zinc-200 divide-y h-auto'>
+    <div className={clsx(
+      'bg-white rounded-md shadow-xs hover:shadow-md overflow-hidden flex flex-col divide-zinc-200 divide-y h-auto',
+      { 'cursor-pointer': props.hit.thumbnail }
+    )} onClick={() => {
+      if (props.hit.thumbnail) {
+        props.setManifestUrl(props.hit.thumbnail?.replace('/thumbnail', '/manifest')); //this is a hack since it looks like we're not storing the manifest URL in typesense? 
+      }
+    }}>
       {props.hit.thumbnail && (
         <img
           alt={props.hit.name}
-          className='object-cover w-full'
+          className='object-cover w-full h-[350px]'
           src={props.hit.thumbnail}
         />
       )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Dispatch, SetStateAction } from "react";
+
 export type Models = 'events' | 'instances' | 'items' | 'mediaContents' | 'organizations' | 'people' | 'places' | 'taxonomies' | 'works';
 
 export interface SearchConfig {
@@ -38,7 +40,7 @@ export interface SearchConfig {
 
   table?: boolean;
 
-  type?: 'grid' | 'list' | 'map';
+  type?: 'grid' | 'image' | 'list' | 'map';
 
   typesense: {
     host: string,
@@ -162,6 +164,7 @@ export interface HitComponentProps {
   }
   highlightComponent?: React.FC<any>;
   hit: any;
+  setManifestUrl?: Dispatch<SetStateAction<string>>
   tags?: {
     name: string;
     primary?: boolean;


### PR DESCRIPTION
### In this PR
Resolves #481 (and also resolves #381 ) by adding a clover viewer to the image search page.
<img width="2441" height="1952" alt="image" src="https://github.com/user-attachments/assets/7ed614e5-468a-4e3d-b53e-cdb350e5452e" />

### Notes
It looks like we're not currently indexing the manifest URL directly in Typesense from what I can tell, but in the case of media records from FairData the manifest URL is determinable from the thumbnail URL, so I'm exploiting that there. If that relationship between the thumbnail and manifest URL were ever broken, this would break. I don't think that's a big deal for now because the whole search interface relies on specific data structures from FairData, but it's worth noting.