### PR TITLE
Update related media on detail pages to use embedded clover viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@performant-software/shared-components": "^3.1.14",
         "@peripleo/maplibre": "^0.8.8",
         "@peripleo/peripleo": "^0.8.8",
-        "@samvera/clover-iiif": "2.9.1",
+        "@samvera/clover-iiif": "^3.3.8",
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.4",
         "@tinacms/cli": "^1.9.2",
@@ -4124,24 +4124,42 @@
         "react": "*"
       }
     },
+    "node_modules/@iiif/helpers": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@iiif/helpers/-/helpers-1.5.8.tgz",
+      "integrity": "sha512-jNLhsmz5LsK3FhBtC6cIEoUM057zVL8zF0a8aQPFM5i6U/tf3QPFiq2mmm3Lop1ORFIZlEJXvsCwk7d3GucB2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@iiif/presentation-2": "1.0.4",
+        "@iiif/presentation-3": "2.2.3",
+        "@iiif/presentation-3-normalized": "0.9.7",
+        "@types/geojson": "7946.0.13"
+      },
+      "optionalDependencies": {
+        "abs-svg-path": "^0.1.1",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      },
+      "peerDependencies": {
+        "@iiif/parser": "^2.2.8"
+      }
+    },
+    "node_modules/@iiif/helpers/node_modules/@types/geojson": {
+      "version": "7946.0.13",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
+      "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==",
+      "license": "MIT"
+    },
     "node_modules/@iiif/parser": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.1.2.tgz",
-      "integrity": "sha512-yjbhSWBB+cWHjAgeWlMYgNydMxDGU1BO3JnmgxCclMcfi59JDsKHMXpgZpCNw+svcirBtIMD2u70KPFinr2pUA==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-2.2.9.tgz",
+      "integrity": "sha512-HJVlnsz6mj56Qda9U7vhXEMxHFuFLeIDTcXqbPEDcuX1iefrWVsuDIY+DxyQO64vBnwme5NWOZbtbO73XNYB6A==",
       "license": "MIT",
       "dependencies": {
         "@iiif/presentation-2": "^1.0.4",
-        "@iiif/presentation-3": "^1.1.3",
-        "@types/geojson": "^7946.0.8"
-      }
-    },
-    "node_modules/@iiif/parser/node_modules/@iiif/presentation-3": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-1.1.3.tgz",
-      "integrity": "sha512-Ek+25nkQouo0pXAqCsWYbAeS4jLDEBQA7iul2jzgnvoJrucxDQN2lXyNLgOUDRqpTdSqJ69iz5lm6DLaxil+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
+        "@iiif/presentation-3": "^2.2.2",
+        "@iiif/presentation-3-normalized": "^0.9.7",
+        "@types/geojson": "^7946.0.10"
       }
     },
     "node_modules/@iiif/presentation-2": {
@@ -4158,9 +4176,17 @@
       "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-2.2.3.tgz",
       "integrity": "sha512-xCLbUr9euqegsrxGe65M2fWbv6gKpiUhHXCpOn+V+qtawkMbOSNWbYOISo2aLQdYVg4DGYD0g2bMzSCF33uNOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/geojson": "^7946.0.10"
+      }
+    },
+    "node_modules/@iiif/presentation-3-normalized": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-3-normalized/-/presentation-3-normalized-0.9.7.tgz",
+      "integrity": "sha512-Aqk0sYBFIH5W3wmVxW02tnAFbNzUU5oPygGQjvszB3PP2nSkFQ1skVjqJhQPPZTyi/de1qcJUrgSy0vp6s+c5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@iiif/presentation-3": "^2.0.5"
       }
     },
     "node_modules/@iiif/vault": {
@@ -4206,6 +4232,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.7"
+      }
+    },
+    "node_modules/@iiif/vault/node_modules/@iiif/parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.1.2.tgz",
+      "integrity": "sha512-yjbhSWBB+cWHjAgeWlMYgNydMxDGU1BO3JnmgxCclMcfi59JDsKHMXpgZpCNw+svcirBtIMD2u70KPFinr2pUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@iiif/presentation-2": "^1.0.4",
+        "@iiif/presentation-3": "^1.1.3",
+        "@types/geojson": "^7946.0.8"
       }
     },
     "node_modules/@iiif/vault/node_modules/@iiif/presentation-3": {
@@ -6359,9 +6396,9 @@
       }
     },
     "node_modules/@nulib/use-markdown": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@nulib/use-markdown/-/use-markdown-0.2.2.tgz",
-      "integrity": "sha512-eS3uhiGm4KlogR3/8cn0gZfxdeMyQuBwyjWXif5c0EBibmiuc7l30xVXqTkwh5teO2Loellfo+782GmHe1DIOA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@nulib/use-markdown/-/use-markdown-0.2.3.tgz",
+      "integrity": "sha512-gQRrLQtHIpqsBkX2ny+zwXBYP6ysyNqhqSgXRt2h2qh8b1ibn6/31tCRqOEyWllrt8GpjCjpD0pKHcISEQINGQ==",
       "dependencies": {
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.0",
@@ -6582,6 +6619,60 @@
         "react": ">= 16.13.1 < 19.0.0",
         "react-dom": ">= 16.13.1 < 19.0.0",
         "tailwindcss": "^4.1.4"
+      }
+    },
+    "node_modules/@performant-software/core-data/node_modules/@iiif/parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@iiif/parser/-/parser-1.1.2.tgz",
+      "integrity": "sha512-yjbhSWBB+cWHjAgeWlMYgNydMxDGU1BO3JnmgxCclMcfi59JDsKHMXpgZpCNw+svcirBtIMD2u70KPFinr2pUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@iiif/presentation-2": "^1.0.4",
+        "@iiif/presentation-3": "^1.1.3",
+        "@types/geojson": "^7946.0.8"
+      }
+    },
+    "node_modules/@performant-software/core-data/node_modules/@iiif/presentation-3": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-1.1.3.tgz",
+      "integrity": "sha512-Ek+25nkQouo0pXAqCsWYbAeS4jLDEBQA7iul2jzgnvoJrucxDQN2lXyNLgOUDRqpTdSqJ69iz5lm6DLaxil+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.7"
+      }
+    },
+    "node_modules/@performant-software/core-data/node_modules/@samvera/clover-iiif": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.9.1.tgz",
+      "integrity": "sha512-aW5M6A3r1Y0fvSWOginPU+lsiaWl2aYvw4cbkZotBP+BztIUmI+bzS/Um2yDSnVeOZRsZ55DYAAVgjj9lRtYEA==",
+      "license": "ISC",
+      "dependencies": {
+        "@iiif/parser": "^1.1.2",
+        "@iiif/vault": "^0.9.22",
+        "@iiif/vault-helpers": "^0.10.0",
+        "@nulib/use-markdown": "^0.2.1",
+        "@radix-ui/react-aspect-ratio": "^1.0.3",
+        "@radix-ui/react-collapsible": "^1.0.3",
+        "@radix-ui/react-form": "^0.0.3",
+        "@radix-ui/react-popover": "^1.0.7",
+        "@radix-ui/react-radio-group": "^1.1.3",
+        "@radix-ui/react-select": "^2.0.0",
+        "@radix-ui/react-switch": "^1.0.3",
+        "@radix-ui/react-tabs": "^1.0.4",
+        "@stitches/react": "^1.2.8",
+        "flexsearch": "^0.7.43",
+        "hls.js": "^1.5.3",
+        "node-webvtt": "^1.9.4",
+        "openseadragon": "^4.1.1",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-error-boundary": "^4.0.12",
+        "sanitize-html": "^2.11.0",
+        "swiper": "^9.4.1",
+        "uuid": "^9.0.1"
+      },
+      "peerDependencies": {
+        "swiper": "^9.0.0"
       }
     },
     "node_modules/@performant-software/core-data/node_modules/@turf/along": {
@@ -8268,6 +8359,41 @@
       "license": "MIT",
       "dependencies": {
         "quickselect": "^1.0.1"
+      }
+    },
+    "node_modules/@performant-software/core-data/node_modules/swiper": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-9.4.1.tgz",
+      "integrity": "sha512-1nT2T8EzUpZ0FagEqaN/YAhRj33F2x/lN6cyB0/xoYJDMf8KwTFT3hMOeoB8Tg4o3+P/CKqskP+WX0Df046fqA==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ssr-window": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 4.7.0"
+      }
+    },
+    "node_modules/@performant-software/core-data/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@performant-software/geospatial": {
@@ -11226,37 +11352,98 @@
       ]
     },
     "node_modules/@samvera/clover-iiif": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.9.1.tgz",
-      "integrity": "sha512-aW5M6A3r1Y0fvSWOginPU+lsiaWl2aYvw4cbkZotBP+BztIUmI+bzS/Um2yDSnVeOZRsZ55DYAAVgjj9lRtYEA==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-3.3.8.tgz",
+      "integrity": "sha512-l28GoZK7qD402LXW/JpZy9FX33hgX0JFNRpcdR6DJhwus6m4WRT9SOPdMSwTDW+w33hWbIyRM2wWcJ4D141JlA==",
       "license": "ISC",
       "dependencies": {
-        "@iiif/parser": "^1.1.2",
-        "@iiif/vault": "^0.9.22",
-        "@iiif/vault-helpers": "^0.10.0",
-        "@nulib/use-markdown": "^0.2.1",
-        "@radix-ui/react-aspect-ratio": "^1.0.3",
-        "@radix-ui/react-collapsible": "^1.0.3",
+        "@iiif/helpers": "^1.2.19",
+        "@iiif/parser": "^2.1.4",
+        "@radix-ui/react-aspect-ratio": "^1.1.0",
+        "@radix-ui/react-checkbox": "^1.1.2",
+        "@radix-ui/react-collapsible": "^1.1.1",
         "@radix-ui/react-form": "^0.0.3",
-        "@radix-ui/react-popover": "^1.0.7",
-        "@radix-ui/react-radio-group": "^1.1.3",
-        "@radix-ui/react-select": "^2.0.0",
-        "@radix-ui/react-switch": "^1.0.3",
-        "@radix-ui/react-tabs": "^1.0.4",
+        "@radix-ui/react-popover": "^1.1.2",
+        "@radix-ui/react-radio-group": "^1.2.1",
+        "@radix-ui/react-select": "^2.1.2",
+        "@radix-ui/react-switch": "^1.1.1",
+        "@radix-ui/react-tabs": "^1.1.1",
         "@stitches/react": "^1.2.8",
         "flexsearch": "^0.7.43",
-        "hls.js": "^1.5.3",
+        "hls.js": "^1.5.17",
+        "i18next": "^23.16.5",
+        "i18next-browser-languagedetector": "^8.0.0",
         "node-webvtt": "^1.9.4",
         "openseadragon": "^4.1.1",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-error-boundary": "^4.0.12",
-        "sanitize-html": "^2.11.0",
-        "swiper": "^9.4.1",
+        "react-error-boundary": "^4.1.2",
+        "react-i18next": "^15.1.1",
+        "react-lazy-load-image-component": "^1.6.2",
+        "rehype-raw": "^7.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "sanitize-html": "^2.13.1",
+        "swiper": "^9.0.0",
+        "unified": "^11.0.5",
         "uuid": "^9.0.1"
       },
+      "engines": {
+        "node": ">=20.10.0"
+      },
       "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0",
         "swiper": "^9.0.0"
+      }
+    },
+    "node_modules/@samvera/clover-iiif/node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/@samvera/clover-iiif/node_modules/react-i18next": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.4.tgz",
+      "integrity": "sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.4.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@samvera/clover-iiif/node_modules/swiper": {
@@ -27013,6 +27200,15 @@
         "@babel/runtime": "^7.12.0"
       }
     },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -28444,6 +28640,12 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "license": "MIT"
     },
     "node_modules/lodash.uniqby": {
@@ -50500,6 +50702,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-lazy-load-image-component": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/react-lazy-load-image-component/-/react-lazy-load-image-component-1.6.3.tgz",
+      "integrity": "sha512-kdQYUDbuISF3T9El0sBLNoWrmPohqlytcG4ognLtHYjY8bZAsJ0/Ez+VaV+0QlVyUY3K6dDXkuQAz3GpvdjBkw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1"
+      },
+      "peerDependencies": {
+        "react": "^15.x.x || ^16.x.x || ^17.x.x || ^18.x.x || ^19.x.x"
+      }
     },
     "node_modules/react-map-gl": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@performant-software/shared-components": "^3.1.14",
     "@peripleo/maplibre": "^0.8.8",
     "@peripleo/peripleo": "^0.8.8",
-    "@samvera/clover-iiif": "2.9.1",
+    "@samvera/clover-iiif": "^3.3.8",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.4",
     "@tinacms/cli": "^1.9.2",

--- a/src/apps/pages/RecordDetail/MediaContents.tsx
+++ b/src/apps/pages/RecordDetail/MediaContents.tsx
@@ -1,17 +1,13 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useTranslations } from '@i18n/useTranslations';
-import { MediaGallery } from '@performant-software/core-data';
 import _ from 'underscore';
-import ManifestThumbnail from '@apps/search/ManifestThumbnail';
-import TranslationContext from '@contexts/TranslationContext';
+import Viewer from '@samvera/clover-iiif/viewer';
 
 interface Props {
   data: any;
-  lang: string;
 }
 
 const MediaContents = (props: Props) => {
-  const [manifestUrl, setManifestUrl] = useState<string | null>(null);
   const { t } = useTranslations();
 
   const count = useMemo(
@@ -19,29 +15,16 @@ const MediaContents = (props: Props) => {
   [props.data])
 
   return (
-    <div className="py-6">
-      <h2 className="capitalize text-lg font-semibold mb-2">{t('relatedMedia', { count })}</h2>
-      <div className='flex gap-6 flex-wrap'>
-        {props.data.items && props.data.items.map(media => (
-          <TranslationContext.Provider
-            value={{ t, lang: props.lang }}
-          >
-            <ManifestThumbnail
-              className='ps-6 pe-6'
-              itemCount={media.item_count}
-              name={_.first(media.label?.en)}
-              onClick={() => setManifestUrl(media.id)}
-              thumbnail={media.thumbnail}
-            />
-          </TranslationContext.Provider>
-        ))}
-        { manifestUrl && (
-          <MediaGallery
-            manifestUrl={manifestUrl}
-            onClose={() => setManifestUrl(null)}
-          />
-        )}
-      </div>
+    <div className='py-6'>
+      <h2 className='capitalize text-lg font-semibold mb-2'>{t('relatedMedia', { count })}</h2>
+      <Viewer 
+        iiifContent={props.data} 
+        options={{
+          informationPanel: {
+            open: false
+          }
+        }} 
+      />
     </div>
   )
 }

--- a/src/apps/pages/RecordDetail/RelatedMedia.astro
+++ b/src/apps/pages/RecordDetail/RelatedMedia.astro
@@ -3,12 +3,11 @@ import ServiceFactory from '@services/coreData/factory';
 import MediaContents from '@apps/pages/RecordDetail/MediaContents';
 
 interface Props {
-  lang: string;
   model: string;
   uuid: string;
 }
 
-const { lang, model, uuid } = Astro.props;
+const { model, uuid } = Astro.props;
 
 const service = ServiceFactory.getService(model);
 const manifests = await service.getRelatedManifests(uuid);
@@ -17,6 +16,5 @@ const manifests = await service.getRelatedManifests(uuid);
   <MediaContents
     client:only='react'
     data={manifests}
-    lang={lang}
   />
 )}


### PR DESCRIPTION
### In this PR
Addresses part of Issue #493 by updating the `RelatedMedia` component to directly embed a clover viewer in the page, rather than using small thumbnails and a modal viewer. The viewer accepts the full collection manifest for the record, meaning that users can select from a dropdown to see different relationships between the models (in the case of the JUEL sites, "Historical Images" and "Renderings").

<img width="2358" height="1435" alt="image" src="https://github.com/user-attachments/assets/762d44b3-ca72-4e9a-827c-c320f75bd306" />
