### PR TITLE
CDP #518 - Back button

### DIFF
--- a/src/apps/detailPages/RecordDetail.astro
+++ b/src/apps/detailPages/RecordDetail.astro
@@ -159,9 +159,6 @@ const faircopyId = ecViewer && record.user_defined ? record.user_defined[ecViewe
 </div>
 
 <script>
-  window.document.addEventListener('DOMContentLoaded', () => {
-    const backButton = document.querySelector('#backButton');
-    const prevURL = document.referrer;
-    backButton.addEventListener('click', () => window.location.href = prevURL)
-  })
+  const backButton = document.querySelector('#backButton');
+  backButton.addEventListener('click', () => history.back());
 </script>


### PR DESCRIPTION
This pull request updates the record detail page back button to use `history.back()` to navigate back to the previous page. Since we've moved the page content to a server island, `document.referrer` will no longer provide the URL of the previous page.

I know this was changed recently due to issues with the button not working in all cases. I was unable to reproduce the problem using `history.back()`, but will certainly look into it if it can be reproduced.