### PR TITLE
CDP #518 - Back button

### DIFF
--- a/src/apps/detailPages/RecordDetail.astro
+++ b/src/apps/detailPages/RecordDetail.astro
@@ -53,8 +53,8 @@ const faircopyId = ecViewer && record.user_defined ? record.user_defined[ecViewe
   <Container>
     <div class='pb-6 flex items-center gap-2'>
       <BackButton
-        id='backButton'
         size={24}
+        client:load
       />
       <span class='uppercase font-semibold'>{t('backTo', { label: t(model) })}</span>
     </div>
@@ -157,8 +157,3 @@ const faircopyId = ecViewer && record.user_defined ? record.user_defined[ecViewe
     />
   </Container>
 </div>
-
-<script>
-  const backButton = document.querySelector('#backButton');
-  backButton.addEventListener('click', () => history.back());
-</script>

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,28 +1,32 @@
 import { Icon } from '@performant-software/core-data/ssr';
 import clsx from 'clsx';
+import { useCallback } from 'react';
 
 interface Props {
   className?: string;
-  id?: string;
-  onClick?(): void;
   size?: number;
 }
 
-const BackButton = (props: Props) => (
-  <button
-    className={clsx(
-      'rounded-full w-8 h-8 flex items-center justify-center',
-      props.className
-    )}
-    id={props.id}
-    onClick={props.onClick}
-    role='button'
-  >
-    <Icon
-      name='left_arrow'
-      size={props.size || 30}
-    />
-  </button>
-);
+const BackButton = (props: Props) => {
+  const onClick = useCallback(() => {
+    window.location.href = document.referrer;
+  }, []);
+
+  return (
+    <button
+      className={clsx(
+        'rounded-full w-8 h-8 flex items-center justify-center',
+        props.className
+      )}
+      onClick={onClick}
+      role='button'
+    >
+      <Icon
+        name='left_arrow'
+        size={props.size || 30}
+      />
+    </button>
+  );
+};
 
 export default BackButton;

--- a/src/pages/[lang]/sessions/search/[id].astro
+++ b/src/pages/[lang]/sessions/search/[id].astro
@@ -23,7 +23,7 @@ export const getStaticPaths = () => [];
   >
     <BackButton
       className='absolute top-[26px]'
-      id='backButton'
+      client:load
     />
     <div
       class='ml-12'
@@ -42,8 +42,3 @@ export const getStaticPaths = () => [];
   title={item?.name}
   client:load
 />
-
-<script>
-  const backButton = document.querySelector('#backButton')
-  backButton.addEventListener('click', () => history.back())
-</script>


### PR DESCRIPTION
This pull request updates the record detail page back button to use `history.back()` to navigate back to the previous page. Since we've moved the page content to a server island, document.referrer will no longer provide the URL of the previous page.

I know this was changed recently due to issues with the button not working in all cases. I was unable to reproduce the problem using `history.back()`, but will certainly look into it if it can be reproduced.