### PR TITLE
Hide content warning field from Clover metadata column

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -151,3 +151,9 @@ const {
     )}
   </body>
 </html>
+
+<style is:global>
+.clover-viewer .clover-viewer-information-panel div[data-label="content-warning"] {
+  display: none;
+}
+</style>


### PR DESCRIPTION
# Summary

This PR adds a global CSS rule to hide the content warning field from the metadata sidebar in the Clover viewer, addressing https://github.com/performant-software/libertos-content/issues/8.