### PR TITLE
Add optional chaining to result card relationship test

### DIFF
--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -272,7 +272,7 @@ describe('search', () => {
         });
       });
 
-      test.skipIf(!search.result_card.relationships)('relationships match allowed values', () => {
+      test.skipIf(!search.result_card?.relationships)('relationships match allowed values', () => {
         expect(search.result_card.relationships).toBeArrayOf(String);
       })
 


### PR DESCRIPTION
# Summary

This PR fixes #530 by adding a `?` to `search.result_card.relationships` in the test.

Now that I look at it, it seems like `result_card` is required and should never be null, but this at least makes that test consistent with the ones around it.