### PR TITLE
CDP #542 - Accessibility documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ npm install && netlify dev
 npm run vitest
 ```
 
+#### Accessibility tests
+
+The accessibility tests must be run against an actual site (either host or local). Set the `A11Y_HOST` environment variable in the `.env` file and then run the following.
+
+```
+npm run playwright
+```
+
+The results will be output to `playwright-report/index.html`.
+
 #### E2E tests
 
 ```

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,8 @@ export default defineConfig({
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['list'],
-    ['json', { outputFile: 'test-results/test-results.json' }]
+    ['json', { outputFile: 'test-results/test-results.json' }],
+    ['html', { open: 'never' }]
   ],
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
This pull request adds the `html` output type to the Playwright tests and updates the `README.md` with documentation on how to run them.