### PR TITLE
Updating related taxonomies to use bullet icon

### DIFF
--- a/src/apps/detailPages/RelatedTaxonomies.astro
+++ b/src/apps/detailPages/RelatedTaxonomies.astro
@@ -22,7 +22,7 @@ const { t } = await getTranslations(lang);
 {Object.keys(relationships).map((uuid) => (
   <Relations
     data={relationships[uuid]}
-    icon='location'
+    icon='bullet'
     label={t(uuid)}
     resolveDetailUrl={(taxonomy) => `/${lang}/taxonomies/${taxonomy.uuid}`}
     resolveName={taxonomy => taxonomy.name}


### PR DESCRIPTION
### In this PR
Resolves #547 by fixing the `icon` prop for related taxonomies to be `bullet`, as intended in the designs. 
<img width="654" height="529" alt="image" src="https://github.com/user-attachments/assets/840a5484-0d51-41e2-8000-56355e44b0b2" />
