### PR TITLE
Update props on footer buttons

### DIFF
--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -99,15 +99,17 @@ setCacheControl(Astro.response.headers);
           class='flex flex-col lg:flex-row lg:w-full lg:justify-center gap-y-4 pb-12'
         >
           <LinkButton
-            className='bg-secondary w-[200px] text-center'
+            className='w-[200px] justify-center'
             content={t('coreDataLogin')}
             href={config.core_data.url}
+            color='secondary'
             target='_blank'
           />
           <LinkButton
-            className='bg-secondary w-[200px] text-center'
+            className='w-[200px] justify-center'
             content={t('tinaLogin')}
             href='/admin/index.html'
+            color='secondary'
             target='_blank'
           />
         </div>


### PR DESCRIPTION
### In this PR
Resolves #374 by updating the footer component to use the `color` prop to specify background color, and using `justify-center` to center the text.
<img width="1475" height="412" alt="image" src="https://github.com/user-attachments/assets/16d04096-cbb2-40bb-b40b-f0bc172a0ed8" />
(Picture for illustrative purposes only; the JUEL sites use custom footers.)