### PR TITLE
Add secondary color to TextImage LinkButton

### DIFF
--- a/src/apps/pages/TextImage.tsx
+++ b/src/apps/pages/TextImage.tsx
@@ -158,7 +158,8 @@ const TextImage = (props: Props) => {
           { !_.isEmpty(props.url) && (
             <div>
               <LinkButton
-                className='bg-secondary mt-8'
+                className='mt-8'
+                color='secondary'
                 content={props.buttonText}
                 href={props.url}
               />


### PR DESCRIPTION
# Summary

This PR adds the `color: 'secondary'` prop to the `LinkButton` within `TextImage`, making it consistent with how the Banner and MultiColumnContent components use it.