### PR TITLE
Fix typo in small caps banner header CSS rule

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -198,7 +198,7 @@ h1:has(+ h1) {
 }
 
 .banner-header {
-  font-variant: var(--Font-Variant-banner-header);
+  font-variant: var(--font-variant-banner-header);
   font-size: var(--font-sizes-CTA-header);
 }
 


### PR DESCRIPTION
# Summary

This PR fixes a capitalization typo that prevented the `small-caps` branding value from being applied to banner headers.