### PR TITLE
use signOut() for Clerk logout

### DIFF
--- a/tina/auth-provider.ts
+++ b/tina/auth-provider.ts
@@ -38,7 +38,7 @@ export class ClerkAuthProvider extends AbstractAuthProvider {
 
   async logout() {
     await this.clerk?.load({ ui });
-    await this.clerk?.session?.remove();
+    await this.clerk?.signOut();
   }
   async authenticate() {
     this.clerk.openSignIn({


### PR DESCRIPTION
## Summary

- Replace `session.remove()` with `signOut()` in the Clerk auth provider's logout method

`session.remove()` ends the current session token but leaves Clerk's browser-level sign-in state intact via cookies. `signOut()` clears both, ensuring a full logout.

In practice the current code works because Clerk's UI re-prompts on the next page load, but `signOut()` is [the documented way](https://clerk.com/docs/references/javascript/clerk/clerk#sign-out) to fully end a Clerk session and is more semantically correct.

## Test plan

- [ ] Log in to /admin via Clerk
- [ ] Log out
- [ ] Revisit /admin — should see Clerk login prompt, not auto-authenticated