### PR TITLE
return 404 for unpublished posts and paths in SSR

### DIFF
--- a/src/apps/paths/Path.astro
+++ b/src/apps/paths/Path.astro
@@ -3,8 +3,12 @@ import PathViewer from '@apps/paths/PathViewer';
 import { fetchPathResponse } from '@backend/tina';
 import PageStoreProvider from '@components/PageStoreProvider';
 
-const { slug } = Astro.props;
+const { slug, publishedOnly } = Astro.props;
 const pathResponse = await fetchPathResponse(slug);
+
+if (publishedOnly && !pathResponse.data?.path?.published) {
+  return new Response(null, { status: 404 });
+}
 
 ---
 

--- a/src/apps/posts/Post.astro
+++ b/src/apps/posts/Post.astro
@@ -9,9 +9,10 @@ import { getRelativeLocaleUrl } from 'astro:i18n';
 
 interface Props {
   slug: string;
+  publishedOnly?: boolean;
 }
 
-const { slug } = Astro.props;
+const { slug, publishedOnly } = Astro.props;
 
 const [{ t }, postResponse] = await Promise.all([
   getTranslations(Astro.currentLocale),
@@ -19,6 +20,10 @@ const [{ t }, postResponse] = await Promise.all([
 ]);
 
 const post = postResponse?.data?.post;
+
+if (publishedOnly && !post.published) {
+  return new Response(null, { status: 404 });
+}
 
 const date = post?.date ? new Date(post.date).toLocaleDateString('en-US', {
   month: 'long',

--- a/src/pages/[lang]/paths/[slug].astro
+++ b/src/pages/[lang]/paths/[slug].astro
@@ -1,12 +1,18 @@
 ---
 import Path from '@apps/paths/Path.astro';
-import { fetchPaths } from '@backend/tina';
+import { fetchPath, fetchPaths } from '@backend/tina';
 import config from '@config';
 import Layout from "@layouts/Layout.astro";
 import { hasPathsContent } from '@utils/config';
 import _ from 'underscore';
 
 const { slug } = Astro.params;
+
+const path = await fetchPath(slug);
+
+if (!path?.published) {
+  return new Response(null, { status: 404 });
+}
 
 export const getStaticPaths = async () => {
   if (!hasPathsContent(config)) {

--- a/src/pages/[lang]/paths/[slug].astro
+++ b/src/pages/[lang]/paths/[slug].astro
@@ -1,18 +1,12 @@
 ---
 import Path from '@apps/paths/Path.astro';
-import { fetchPath, fetchPaths } from '@backend/tina';
+import { fetchPaths } from '@backend/tina';
 import config from '@config';
 import Layout from "@layouts/Layout.astro";
 import { hasPathsContent } from '@utils/config';
 import _ from 'underscore';
 
 const { slug } = Astro.params;
-
-const path = await fetchPath(slug);
-
-if (!path?.published) {
-  return new Response(null, { status: 404 });
-}
 
 export const getStaticPaths = async () => {
   if (!hasPathsContent(config)) {
@@ -45,6 +39,7 @@ export const getStaticPaths = async () => {
 >
   <Path
     slug={slug}
+    publishedOnly={true}
     server:defer
   />
 </Layout>

--- a/src/pages/[lang]/posts/[slug].astro
+++ b/src/pages/[lang]/posts/[slug].astro
@@ -1,12 +1,18 @@
 ---
 import Post from '@apps/posts/Post.astro';
-import { fetchPosts } from '@backend/tina';
+import { fetchPost, fetchPosts } from '@backend/tina';
 import config from '@config';
 import Layout from '@layouts/Layout.astro';
 import { hasPostsContent } from '@utils/config';
 import _ from 'underscore';
 
 const { slug } = Astro.params;
+
+const post = await fetchPost(slug);
+
+if (!post?.published) {
+  return new Response(null, { status: 404 });
+}
 
 export const getStaticPaths = async () => {
   if (!hasPostsContent(config)) {

--- a/src/pages/[lang]/posts/[slug].astro
+++ b/src/pages/[lang]/posts/[slug].astro
@@ -1,18 +1,12 @@
 ---
 import Post from '@apps/posts/Post.astro';
-import { fetchPost, fetchPosts } from '@backend/tina';
+import { fetchPosts } from '@backend/tina';
 import config from '@config';
 import Layout from '@layouts/Layout.astro';
 import { hasPostsContent } from '@utils/config';
 import _ from 'underscore';
 
 const { slug } = Astro.params;
-
-const post = await fetchPost(slug);
-
-if (!post?.published) {
-  return new Response(null, { status: 404 });
-}
 
 export const getStaticPaths = async () => {
   if (!hasPostsContent(config)) {
@@ -45,6 +39,7 @@ export const getStaticPaths = async () => {
 >
   <Post
     slug={slug}
+    publishedOnly={true}
     server:defer
   />
 </Layout>


### PR DESCRIPTION
## Summary

- Check `published` status in post and path page routes before rendering
- Return 404 for unpublished content in SSR mode

In SSR mode, dynamic routes handle any slug regardless of `getStaticPaths`. The `getStaticPaths` filter (`published: { eq: true }`) only affects static builds. This meant unpublished posts/paths were accessible by direct URL on SSR deploys.

The API routes (`/api/posts/`) already filter by published status, so post/path lists were correct — only direct URL access was affected.

## Test plan

- [ ] Create a post in Tina without checking "published"
- [ ] Visit that post's URL in an incognito window — should get 404
- [ ] Create a post and check "published" — should be accessible
- [ ] Same for paths
- [ ] Post/path list pages should continue to show only published content