### PR TITLE
pre-build before netlify dev to avoid CLI timeout

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -341,7 +341,13 @@ restore_env() {
 }
 trap restore_env EXIT
 
-# Step 8: Start dev server
+# Step 8: Pre-build with Netlify env vars (before netlify dev timeout kicks in)
+info "Running pre-build with Netlify env vars..."
+npx netlify dev:exec node scripts/build.mjs
+success "Pre-build complete"
+echo ""
+
+# Step 9: Start dev server (skip build.mjs, already done)
 export USE_CONTENT_CACHE=true
 info "Starting dev server (USE_CONTENT_CACHE=true)..."
 echo ""


### PR DESCRIPTION
## Summary

- Run `build.mjs` via `netlify dev:exec` before starting `netlify dev`

The Netlify CLI has a hardcoded timeout waiting for the framework server port. For sites with large content repos or slow content loaders (e.g., geometry-loader), the build + TinaCMS + Astro startup exceeds this timeout.

Running the build step first via `netlify dev:exec` (which injects Netlify env vars) means `netlify dev` only needs to wait for TinaCMS + Astro to start — not the full build pipeline.

Tested with PADP staging, which was consistently timing out before this change.

## Test plan

- [ ] `npm run dev -- <site>` completes the pre-build step and starts the dev server
- [ ] Env vars are correctly injected during the pre-build
- [ ] Content is cloned and generated files are created before `netlify dev` starts