### PR TITLE
Admin redirect

### DIFF
--- a/netlify/edge-functions/rebuild.ts
+++ b/netlify/edge-functions/rebuild.ts
@@ -2,10 +2,10 @@ import type { Context } from '@netlify/edge-functions';
 import { Clerk } from '@clerk/backend';
 
 const BASE_URL = 'https://api.netlify.com/api/v1';
-const NETLIFY_TOKEN = process.env.NETLIFY_TOKEN!;
+const NETLIFY_TOKEN = Netlify.env.get('NETLIFY_TOKEN')!;
 
 const clerkClient = Clerk({
-  secretKey: process.env.CLERK_SECRET,
+  secretKey: Netlify.env.get('CLERK_SECRET')!,
 });
 
 function buildResponse(statusCode: number, body: any | null): Response {
@@ -25,7 +25,7 @@ async function authenticate(req: Request): Promise<boolean> {
 
   const { sessionClaims } = toAuth();
 
-  const isMember = sessionClaims.o.id === process.env.TINA_PUBLIC_CLERK_ORG_ID
+  const isMember = sessionClaims.o.id === Netlify.env.get('TINA_PUBLIC_CLERK_ORG_ID')
   const isAdmin = sessionClaims.o.rol === 'admin'
 
   return isMember && isAdmin;

--- a/netlify/edge-functions/redirect.ts
+++ b/netlify/edge-functions/redirect.ts
@@ -14,8 +14,6 @@ export default async (request: Request, context: Context) => {
 
   const url = new URL(request.url);
 
-  console.log(url.hostname, url.pathname);
-
   if (url.hostname === publicDomain && url.pathname.startsWith('/admin')) {
     url.hostname = adminDomain;
     url.port = '';

--- a/netlify/edge-functions/redirect.ts
+++ b/netlify/edge-functions/redirect.ts
@@ -1,0 +1,31 @@
+import type { Config, Context } from '@netlify/edge-functions';
+
+const publicDomain = Netlify.env.get('PUBLIC_DOMAIN');
+const adminDomain = Netlify.env.get('ADMIN_DOMAIN');
+
+export default async (request: Request, context: Context) => {
+  if (request.headers.get('sec-fetch-dest') === 'iframe') {
+    return context.next();
+  }
+
+  const url = new URL(request.url);
+
+  console.log(url.hostname, url.pathname);
+
+  if (url.hostname === publicDomain && url.pathname.startsWith('/admin')) {
+    url.hostname = adminDomain;
+    url.port = '';
+    return Response.redirect(url.toString(), 301);
+  }
+
+  if (url.hostname === adminDomain && !url.pathname.startsWith('/admin')) {
+    url.hostname = publicDomain;
+    return Response.redirect(url.toString(), 301);
+  }
+
+  return context.next();
+};
+
+export const config: Config = {
+  path: '/*',
+};

--- a/netlify/edge-functions/redirect.ts
+++ b/netlify/edge-functions/redirect.ts
@@ -4,6 +4,10 @@ const publicDomain = Netlify.env.get('PUBLIC_DOMAIN');
 const adminDomain = Netlify.env.get('ADMIN_DOMAIN');
 
 export default async (request: Request, context: Context) => {
+  if (!publicDomain || !adminDomain) {
+    return context.next();
+  }
+
   if (request.headers.get('sec-fetch-dest') === 'iframe') {
     return context.next();
   }

--- a/public/config.json
+++ b/public/config.json
@@ -1,51 +1,166 @@
 {
+  "branding": {
+    "header_hide_title": false,
+    "footer_hide_title": false,
+    "footer_login": true
+  },
   "content": {
     "collections": [
       "paths",
       "posts"
-    ]
+    ],
+    "posts_config": {
+      "layout": "grid"
+    }
   },
   "core_data": {
     "url": "https://staging.coredata.cloud",
     "project_ids": [
-      "1",
-      "2",
-      "3"
+      "230"
     ]
+  },
+  "detail_pages": {
+    "models": {
+      "events": {},
+      "organizations": {},
+      "people": {}
+    }
   },
   "i18n": {
     "default_locale": "en",
-    "locales": ["en"]
+    "locales": [
+      "en"
+    ]
   },
-  "layers": [{
-    "name": "Maptiler DataViz Style",
-    "layer_type": "vector",
-    "url": "https://api.maptiler.com/maps/dataviz/style.json?key=WLMbLZP1AwK3zUFTeheB"
-  }],
-  "search": [{
-    "name": "places",
-    "route": "/places",
-    "geosearch": true,
-    "map": {
-      "clusterRadius": 6,
-      "geometry": "geometry",
-      "max_zoom": 14,
-      "zoom_to_place": true
+  "layers": [
+    {
+      "name": "Maptiler DataViz Style",
+      "layer_type": "vector",
+      "url": "https://api.maptiler.com/maps/dataviz/style.json?key=WLMbLZP1AwK3zUFTeheB"
+    }
+  ],
+  "result_filtering": {
+    "events": {
+      "exclude": [
+        "a69b5ef5-f119-4b2f-8a33-dfce360e172d"
+      ]
     },
-    "result_card": {
-      "title": "name"
+    "people": {
+      "exclude": [
+        "3d0b932c-fec0-4b83-97aa-63ab4ccc0657",
+        "1bf54ef5-adba-45bb-9ee3-3d3a5f78de01"
+      ]
+    }
+  },
+  "search": [
+    {
+      "name": "events",
+      "route": "/events",
+      "facets": [
+        {
+          "name": "cb9e196b-0151-4584-a295-454404aff84b.names_facet",
+          "type": "select"
+        }
+      ],
+      "map": {
+        "geometry": "cb9e196b-0151-4584-a295-454404aff84b.geometry",
+        "max_zoom": 14,
+        "zoom_to_place": true
+      },
+      "result_card": {
+        "title": "name"
+      },
+      "timeline": {
+        "date_range_facet": "start_year_facet"
+      },
+      "typesense": {
+        "host": "i74olkjcuy69ze2vp-1.a1.typesense.net",
+        "port": 443,
+        "protocol": "https",
+        "api_key": "Qu4sjurXtgQKXIX4pxUyjmiaOtjP7YPS",
+        "index_name": "padp_events",
+        "query_by": "name",
+        "default_sort": "name",
+        "facets": {
+          "include": [
+            "start_year_facet",
+            "end_year_facet",
+            "cb9e196b-0151-4584-a295-454404aff84b.names_facet",
+            "0512f56e-385d-4f2c-8e4c-61968f84212c.name_facet"
+          ]
+        }
+      }
     },
-    "typesense": {
-      "host": "example.typesense.com",
-      "port": 443,
-      "protocol": "https",
-      "api_key": "abcdefg",
-      "index_name": "core_data_places",
-      "query_by": "name",
-      "default_sort": "name",
-      "overrides": {
-        "geoLocationField": "coordinates"
+    {
+      "name": "people",
+      "route": "/people",
+      "map": {
+        "geometry": "e9e676dc-5297-4227-ab01-fb710b7f67ce.geometry",
+        "max_zoom": 14,
+        "zoom_to_place": true
+      },
+      "result_card": {
+        "title": "name"
+      },
+      "typesense": {
+        "host": "i74olkjcuy69ze2vp-1.a1.typesense.net",
+        "port": 443,
+        "protocol": "https",
+        "api_key": "fJr1a9G307zqpTpkGkDak6Lw7ahxXJPw",
+        "index_name": "padp_people",
+        "query_by": "name",
+        "default_sort": "name",
+        "facets": {
+          "include": [
+            "ea3f1de5-9122-4962-90a9-858c0483b9e7_facet",
+            "event_range_facet",
+            "9dd32cae-d1bc-48ad-8245-1000346b3386.name_facet",
+            "0512f56e-385d-4f2c-8e4c-61968f84212c.start_year_facet",
+            "0512f56e-385d-4f2c-8e4c-61968f84212c.end_year_facet",
+            "0512f56e-385d-4f2c-8e4c-61968f84212c.name_facet",
+            "ea3f1de5-9122-4962-90a9-858c0483b9e7_facet",
+            "0512f56e-385d-4f2c-8e4c-61968f84212c.names_facet"
+          ]
+        }
+      }
+    },
+    {
+      "name": "organizations",
+      "route": "/organizations",
+      "facets": [
+        {
+          "name": "7e4cc022-7fe4-47d4-823b-5f5fa69298e8.names_facet",
+          "type": "select"
+        }
+      ],
+      "map": {
+        "geometry": "7e4cc022-7fe4-47d4-823b-5f5fa69298e8.geometry",
+        "max_zoom": 14,
+        "zoom_to_place": true
+      },
+      "result_card": {
+        "title": "name"
+      },
+      "timeline": {
+        "date_range_facet": "84b4aa28-be46-474a-acd7-30bfcf6a444c.start_year_facet",
+        "event_path": "84b4aa28-be46-474a-acd7-30bfcf6a444c"
+      },
+      "typesense": {
+        "host": "i74olkjcuy69ze2vp-1.a1.typesense.net",
+        "port": 443,
+        "protocol": "https",
+        "api_key": "DXMrSPNPrYYhUkeu4LdzdzQu8Yr5iBRq",
+        "index_name": "padp_organizations",
+        "query_by": "name",
+        "default_sort": "name",
+        "facets": {
+          "include": [
+            "84b4aa28-be46-474a-acd7-30bfcf6a444c.start_year_facet",
+            "7e4cc022-7fe4-47d4-823b-5f5fa69298e8.names_facet",
+            "9dd32cae-d1bc-48ad-8245-1000346b3386.name_facet"
+          ]
+        }
       }
     }
-  }]
+  ]
 }

--- a/public/config.json
+++ b/public/config.json
@@ -1,166 +1,51 @@
 {
-  "branding": {
-    "header_hide_title": false,
-    "footer_hide_title": false,
-    "footer_login": true
-  },
   "content": {
     "collections": [
       "paths",
       "posts"
-    ],
-    "posts_config": {
-      "layout": "grid"
-    }
+    ]
   },
   "core_data": {
     "url": "https://staging.coredata.cloud",
     "project_ids": [
-      "230"
+      "1",
+      "2",
+      "3"
     ]
-  },
-  "detail_pages": {
-    "models": {
-      "events": {},
-      "organizations": {},
-      "people": {}
-    }
   },
   "i18n": {
     "default_locale": "en",
-    "locales": [
-      "en"
-    ]
+    "locales": ["en"]
   },
-  "layers": [
-    {
-      "name": "Maptiler DataViz Style",
-      "layer_type": "vector",
-      "url": "https://api.maptiler.com/maps/dataviz/style.json?key=WLMbLZP1AwK3zUFTeheB"
-    }
-  ],
-  "result_filtering": {
-    "events": {
-      "exclude": [
-        "a69b5ef5-f119-4b2f-8a33-dfce360e172d"
-      ]
+  "layers": [{
+    "name": "Maptiler DataViz Style",
+    "layer_type": "vector",
+    "url": "https://api.maptiler.com/maps/dataviz/style.json?key=WLMbLZP1AwK3zUFTeheB"
+  }],
+  "search": [{
+    "name": "places",
+    "route": "/places",
+    "geosearch": true,
+    "map": {
+      "clusterRadius": 6,
+      "geometry": "geometry",
+      "max_zoom": 14,
+      "zoom_to_place": true
     },
-    "people": {
-      "exclude": [
-        "3d0b932c-fec0-4b83-97aa-63ab4ccc0657",
-        "1bf54ef5-adba-45bb-9ee3-3d3a5f78de01"
-      ]
-    }
-  },
-  "search": [
-    {
-      "name": "events",
-      "route": "/events",
-      "facets": [
-        {
-          "name": "cb9e196b-0151-4584-a295-454404aff84b.names_facet",
-          "type": "select"
-        }
-      ],
-      "map": {
-        "geometry": "cb9e196b-0151-4584-a295-454404aff84b.geometry",
-        "max_zoom": 14,
-        "zoom_to_place": true
-      },
-      "result_card": {
-        "title": "name"
-      },
-      "timeline": {
-        "date_range_facet": "start_year_facet"
-      },
-      "typesense": {
-        "host": "i74olkjcuy69ze2vp-1.a1.typesense.net",
-        "port": 443,
-        "protocol": "https",
-        "api_key": "Qu4sjurXtgQKXIX4pxUyjmiaOtjP7YPS",
-        "index_name": "padp_events",
-        "query_by": "name",
-        "default_sort": "name",
-        "facets": {
-          "include": [
-            "start_year_facet",
-            "end_year_facet",
-            "cb9e196b-0151-4584-a295-454404aff84b.names_facet",
-            "0512f56e-385d-4f2c-8e4c-61968f84212c.name_facet"
-          ]
-        }
-      }
+    "result_card": {
+      "title": "name"
     },
-    {
-      "name": "people",
-      "route": "/people",
-      "map": {
-        "geometry": "e9e676dc-5297-4227-ab01-fb710b7f67ce.geometry",
-        "max_zoom": 14,
-        "zoom_to_place": true
-      },
-      "result_card": {
-        "title": "name"
-      },
-      "typesense": {
-        "host": "i74olkjcuy69ze2vp-1.a1.typesense.net",
-        "port": 443,
-        "protocol": "https",
-        "api_key": "fJr1a9G307zqpTpkGkDak6Lw7ahxXJPw",
-        "index_name": "padp_people",
-        "query_by": "name",
-        "default_sort": "name",
-        "facets": {
-          "include": [
-            "ea3f1de5-9122-4962-90a9-858c0483b9e7_facet",
-            "event_range_facet",
-            "9dd32cae-d1bc-48ad-8245-1000346b3386.name_facet",
-            "0512f56e-385d-4f2c-8e4c-61968f84212c.start_year_facet",
-            "0512f56e-385d-4f2c-8e4c-61968f84212c.end_year_facet",
-            "0512f56e-385d-4f2c-8e4c-61968f84212c.name_facet",
-            "ea3f1de5-9122-4962-90a9-858c0483b9e7_facet",
-            "0512f56e-385d-4f2c-8e4c-61968f84212c.names_facet"
-          ]
-        }
-      }
-    },
-    {
-      "name": "organizations",
-      "route": "/organizations",
-      "facets": [
-        {
-          "name": "7e4cc022-7fe4-47d4-823b-5f5fa69298e8.names_facet",
-          "type": "select"
-        }
-      ],
-      "map": {
-        "geometry": "7e4cc022-7fe4-47d4-823b-5f5fa69298e8.geometry",
-        "max_zoom": 14,
-        "zoom_to_place": true
-      },
-      "result_card": {
-        "title": "name"
-      },
-      "timeline": {
-        "date_range_facet": "84b4aa28-be46-474a-acd7-30bfcf6a444c.start_year_facet",
-        "event_path": "84b4aa28-be46-474a-acd7-30bfcf6a444c"
-      },
-      "typesense": {
-        "host": "i74olkjcuy69ze2vp-1.a1.typesense.net",
-        "port": 443,
-        "protocol": "https",
-        "api_key": "DXMrSPNPrYYhUkeu4LdzdzQu8Yr5iBRq",
-        "index_name": "padp_organizations",
-        "query_by": "name",
-        "default_sort": "name",
-        "facets": {
-          "include": [
-            "84b4aa28-be46-474a-acd7-30bfcf6a444c.start_year_facet",
-            "7e4cc022-7fe4-47d4-823b-5f5fa69298e8.names_facet",
-            "9dd32cae-d1bc-48ad-8245-1000346b3386.name_facet"
-          ]
-        }
+    "typesense": {
+      "host": "example.typesense.com",
+      "port": 443,
+      "protocol": "https",
+      "api_key": "abcdefg",
+      "index_name": "core_data_places",
+      "query_by": "name",
+      "default_sort": "name",
+      "overrides": {
+        "geoLocationField": "coordinates"
       }
     }
-  ]
+  }]
 }


### PR DESCRIPTION
# Summary

This PR adds a new Netlify edge function that runs on every request to implement the admin vs. public site redirect functionality It requires two new environment variables: `PUBLIC_DOMAIN` and `ADMIN_DOMAIN`.

* if you visit `${PUBLIC_DOMAIN}/admin/*`, you'll be redirected to `${ADMIN_DOMAIN}/admin/*`
* If you visit any other path on `ADMIN_DOMAIN`, you'll be redirected to `PUBLIC_DOMAIN`
* **However**, if your request is coming from inside an `iframe`, you will not be redirected in any circumstance. This addresses the issue we've been seeing with the current functionality breaking the `iframe` in the Tina visual editor.

I also updated the `rebuild` edge function to switch from `process.env` to `Netlify.env.get()`, which I learned was the proper way to access environment variables within an edge function as I worked on this.