### PR TITLE
Add `/_astro` to routes ignored by redirect

### DIFF
--- a/netlify/edge-functions/redirect.ts
+++ b/netlify/edge-functions/redirect.ts
@@ -10,7 +10,8 @@ const secFetchHeaders = [
 
 const ignorePaths = [
   '/api/tina',
-  '/api/s3/'
+  '/api/s3/',
+  '/_astro'
 ]
 
 export default async (request: Request, context: Context) => {


### PR DESCRIPTION
# Summary

This PR adds the `/_astro` path to the list of routes ignored by the redirect edge function.