### PR TITLE
Fix pathname logic in `redirect` edge function

### DIFF
--- a/netlify/edge-functions/redirect.ts
+++ b/netlify/edge-functions/redirect.ts
@@ -10,7 +10,7 @@ const secFetchHeaders = [
 
 const ignorePaths = [
   '/api/tina',
-  '/api/s3/',
+  '/api/s3',
   '/_astro'
 ]
 
@@ -23,11 +23,11 @@ export default async (request: Request, context: Context) => {
     return context.next();
   }
 
-  if (ignorePaths.some(path => request.url.startsWith(path))) {
+  const url = new URL(request.url);
+
+  if (ignorePaths.some(path => url.pathname.startsWith(path))) {
     return context.next();
   }
-
-  const url = new URL(request.url);
 
   if (url.hostname === publicDomain && url.pathname.startsWith('/admin')) {
     url.hostname = adminDomain;


### PR DESCRIPTION
# Summary

This PR fixes an issue where we were matching the full URL to the ignore list instead of just the path name.

(This explains why the `/_astro` ignore wasn't working, but I don't know why the other ignore paths were working just fine.)