### PR TITLE
Fixing visual editing errors from post inserts

### DIFF
--- a/src/apps/posts/PlaceInsert.tsx
+++ b/src/apps/posts/PlaceInsert.tsx
@@ -7,7 +7,7 @@ import React, { useMemo } from 'react';
 const PlaceInsert = (props: any) => {
   const { selection, setSelection } = useSelectionState();
 
-  if (!props.place) {
+  if (!props.place?.uuid) {
     return null;
   }
 

--- a/src/apps/posts/PlaceInsert.tsx
+++ b/src/apps/posts/PlaceInsert.tsx
@@ -7,16 +7,12 @@ import React, { useMemo } from 'react';
 const PlaceInsert = (props: any) => {
   const { selection, setSelection } = useSelectionState();
 
-  if (!props.place?.uuid) {
-    return null;
-  }
-
   /**
    * Memo-izes the properties of the selected feature.
    */
   const place = useMemo(() => parseFeature(selection), [selection]);
 
-  return (
+  return props.place?.uuid && (
     <div
       className='flex flex-col gap-y-2 my-8 w-full'
     >

--- a/src/components/MediaInsert.tsx
+++ b/src/components/MediaInsert.tsx
@@ -2,6 +2,11 @@ import Viewer from '@samvera/clover-iiif/viewer';
 import clsx from 'clsx';
 
 const MediaInsert = (props: any) => {
+
+  if (!props?.media?.manifest_url) {
+    return null;
+  }
+  
   return (
     <div
       className={clsx(

--- a/src/visualizations/EventsByYear.tsx
+++ b/src/visualizations/EventsByYear.tsx
@@ -20,16 +20,12 @@ const DEFAULT_INTERVAL = 10;
 const EventsByYear = (props: Props) => {
   const { interval = DEFAULT_INTERVAL } = props;
 
-  if (!props.data) {
-    return null;
-  }
-
   /**
    * Memo-izes the data as parsed JSON.
-   */
-  const data = useMemo(() => JSON.parse(props.data), [props.data]);
+  */
+  const data = useMemo(() => props.data ? JSON.parse(props.data) : null, [props.data]);
 
-  return (
+  return data && (
     <VisualizationContainer
       title={props.title}
     >

--- a/src/visualizations/EventsByYear.tsx
+++ b/src/visualizations/EventsByYear.tsx
@@ -20,6 +20,10 @@ const DEFAULT_INTERVAL = 10;
 const EventsByYear = (props: Props) => {
   const { interval = DEFAULT_INTERVAL } = props;
 
+  if (!props.data) {
+    return null;
+  }
+
   /**
    * Memo-izes the data as parsed JSON.
    */

--- a/src/visualizations/Map.tsx
+++ b/src/visualizations/Map.tsx
@@ -11,6 +11,10 @@ import _ from 'underscore';
 const Map = (props: DataVisualizationProps) => {
   const [features, setFeatures] = useState([]);
 
+  if (!props.data) {
+    return null;
+  }
+
   const runtimeConfig = useRuntimeConfig<Configuration>();
 
   /**
@@ -59,12 +63,14 @@ const Map = (props: DataVisualizationProps) => {
       <div
         className='h-[400px]'
       >
-        <BaseMap>
-          <LocationMarkers
-            boundingBoxOptions={{ padding: 20 }}
-            data={MapUtils.toFeatureCollection(features)}
-          />
-        </BaseMap>
+        { features && (
+          <BaseMap>
+            <LocationMarkers
+              boundingBoxOptions={{ padding: 20 }}
+              data={MapUtils.toFeatureCollection(features)}
+            />
+          </BaseMap> 
+        )}
       </div>
     </VisualizationContainer>
   );

--- a/src/visualizations/Map.tsx
+++ b/src/visualizations/Map.tsx
@@ -11,27 +11,23 @@ import _ from 'underscore';
 const Map = (props: DataVisualizationProps) => {
   const [features, setFeatures] = useState([]);
 
-  if (!props.data) {
-    return null;
-  }
-
   const runtimeConfig = useRuntimeConfig<Configuration>();
 
   /**
    * Memo-izes the "data" prop as JSON.
    */
-  const parsed = useMemo(() => JSON.parse(props.data), [props.data]);
+  const parsed = useMemo(() => props.data ? JSON.parse(props.data) : null, [props.data]);
 
   /**
    * Memo-izes the search config based on the data set.
    */
-  const config = useMemo(() => _.findWhere(runtimeConfig.search, { name: parsed.name }), [parsed, runtimeConfig]);
+  const config = useMemo(() => parsed ? _.findWhere(runtimeConfig.search, { name: parsed.name }) : null, [parsed, runtimeConfig]);
 
   /**
    * If the data set contains the features data, fetch the geometry for each.
    */
   useEffect(() => {
-    if (parsed.data.features) {
+    if (parsed?.data?.features) {
       const promises = _.map(parsed.data.features, ({ properties }) => (
         fetchGeometry(properties.uuid)
           .then((data) => ({ data, properties }))
@@ -48,7 +44,7 @@ const Map = (props: DataVisualizationProps) => {
    * If the data set does not contain the features data, pull the geometry directly off the hits.
    */
   useEffect(() => {
-    if (!parsed.data.features) {
+    if (parsed?.data && !parsed?.data?.features) {
       const { hits } = parsed.data;
       const { geometry } = config.map;
 
@@ -56,7 +52,7 @@ const Map = (props: DataVisualizationProps) => {
     }
   }, [parsed]);
 
-  return (
+  return parsed && (
     <VisualizationContainer
       title={props.title}
     >

--- a/src/visualizations/StackedTimeline.tsx
+++ b/src/visualizations/StackedTimeline.tsx
@@ -45,6 +45,10 @@ const CustomTooltip = ({ active, payload, label }: TooltipContentProps<string | 
 
 const StackedTimeline = (props: Props) => {
   const { link, model, filter } = props;
+
+  if (!props.data) {
+    return null;
+  }
   
   /**
    * Memo-izes the data as parsed JSON.

--- a/src/visualizations/StackedTimeline.tsx
+++ b/src/visualizations/StackedTimeline.tsx
@@ -45,15 +45,11 @@ const CustomTooltip = ({ active, payload, label }: TooltipContentProps<string | 
 
 const StackedTimeline = (props: Props) => {
   const { link, model, filter } = props;
-
-  if (!props.data) {
-    return null;
-  }
   
   /**
    * Memo-izes the data as parsed JSON.
   */
- const data = useMemo(() => JSON.parse(props.data), [props.data]);
+ const data = useMemo(() => props.data ? JSON.parse(props.data) : null, [props.data]);
 
  const language = useMemo(() => getLanguageFromUrl(window.location.pathname), [window.location.pathname]);
 
@@ -80,7 +76,7 @@ const StackedTimeline = (props: Props) => {
    );
  }, [data]);
 
-  return (
+  return data && (
     <VisualizationContainer
       title={props.title}
     >

--- a/src/visualizations/Table.tsx
+++ b/src/visualizations/Table.tsx
@@ -8,24 +8,20 @@ import _ from 'underscore';
 const Table = (props: DataVisualizationProps) => {
   const { t } = useContext(TranslationContext);
 
-  if (!props.data) {
-    return null;
-  }
-
   /**
    * Memo-izes the data as JSON.
    */
-  const { data } = useMemo(() => JSON.parse(props.data), [props.data]);
+  const { data } = useMemo(() => props.data ? JSON.parse(props.data) : null, [props.data]);
 
   /**
    * Memo-izes the table columns and labels.
    */
-  const columns = useMemo(() => _.map(data.columns, (column) => ({
+  const columns = useMemo(() => _.map(data?.columns, (column) => ({
     name: column,
     label: t(column)
   })), [data, t]);
 
-  return (
+  return data && (
     <VisualizationContainer
       title={props.title}
     >

--- a/src/visualizations/Table.tsx
+++ b/src/visualizations/Table.tsx
@@ -8,6 +8,10 @@ import _ from 'underscore';
 const Table = (props: DataVisualizationProps) => {
   const { t } = useContext(TranslationContext);
 
+  if (!props.data) {
+    return null;
+  }
+
   /**
    * Memo-izes the data as JSON.
    */

--- a/src/visualizations/Timeline.tsx
+++ b/src/visualizations/Timeline.tsx
@@ -5,25 +5,21 @@ import React, { useMemo } from 'react';
 import _ from 'underscore';
 
 const TimelineVisualization = (props: DataVisualizationProps) => {
-
-  if (!props.data) {
-    return null;
-  }
   
   /**
    * Memo-izes the "data" prop as JSON.
    */
-  const data = useMemo(() => JSON.parse(props.data), [props.data]);
+  const data = useMemo(() => props.data ? JSON.parse(props.data) : null, [props.data]);
 
   /**
    * Memo-izes the events and sets the "date" attribute.
    */
-  const events = useMemo(() => _.map(data.events, (event) => ({
+  const events = useMemo(() => _.map(data?.events, (event) => ({
     ...event,
     date: TypesenseUtils.getDate(event)
   })), [data]);
 
-  return (
+  return data && (
     <VisualizationContainer
       title={props.title}
     >

--- a/src/visualizations/Timeline.tsx
+++ b/src/visualizations/Timeline.tsx
@@ -5,6 +5,11 @@ import React, { useMemo } from 'react';
 import _ from 'underscore';
 
 const TimelineVisualization = (props: DataVisualizationProps) => {
+
+  if (!props.data) {
+    return null;
+  }
+  
   /**
    * Memo-izes the "data" prop as JSON.
    */


### PR DESCRIPTION
### In this PR
Fixes an issue where attempting to insert certain MDX components in a path or post crashes the visual editor. The issue seems to be in the component attempting to render on the page before containing any data, so this fix just adds a check for whether any data was actually passed to the component and returns `null` if not.