### PR TITLE
Add certainty radius to bounding box

### DIFF
--- a/src/apps/detailPages/PlaceMap.tsx
+++ b/src/apps/detailPages/PlaceMap.tsx
@@ -5,6 +5,8 @@ import Map from '@components/Map';
 import TranslationContext from '@contexts/TranslationContext';
 import { useTranslations } from '@i18n/useTranslations';
 import CertaintyLayer from '@components/CertaintyLayer';
+import { useMemo } from 'react';
+import { kilometersToMiles } from '@utils/map';
 
 interface Props {
   classNames?: {
@@ -21,6 +23,10 @@ interface Props {
 const PlaceMap = (props: Props) => {
   const { t } = useTranslations();
 
+  const buffer = useMemo(() => (
+    kilometersToMiles(props.geometry.properties?.certainty_radius)
+  ), [props.geometry.properties?.certainty_radius]);
+
   return (
     <TranslationContext.Provider
       value={{ t, lang: props.lang }}
@@ -35,6 +41,7 @@ const PlaceMap = (props: Props) => {
               boundingBoxOptions={{
                 animate: false
               }}
+              buffer={buffer}
               data={props.geometry.geometry_json}
             />
             <CertaintyLayer

--- a/src/apps/search/map/panels/BasePanel.tsx
+++ b/src/apps/search/map/panels/BasePanel.tsx
@@ -26,6 +26,7 @@ import {
 import _ from 'underscore';
 import PanelHistoryContext from '@apps/search/map/PanelHistoryContext';
 import { useSearchConfig } from '@apps/search/SearchConfigContext';
+import { kilometersToMiles } from '@utils/map';
 
 interface Props {
   className?: string;
@@ -210,17 +211,25 @@ const { data: { people = [] } = {}, loading: peopleLoading } = useLoader(onLoadP
   /**
    * Memo-izes the geometry.
    */
-  const geometry = useMemo(() => {
+  const geometryData = useMemo(() => {
     if (props.resolveGeometry && item) {
       return props.resolveGeometry(item);
     }
 
-    return !_.isEmpty(places.filter((place) => place.place_geometry)) &&
-      CoreDataUtils.toFeatureCollection(
-        places.filter((place) => place.place_geometry)
-      );
+    if (!_.isEmpty(places.filter((place) => place.place_geometry))) {
+      return {
+        geometry: CoreDataUtils.toFeatureCollection(
+          places.filter((place) => place.place_geometry)
+        ),
+        properties: {
+          certainty_radius: Math.max(places.map(p => p.place_geometry?.properties?.certainty_radius || 0))
+        }
+      }
+    }
+
+    return null;
   }, [item, places, props.resolveGeometry]);
-  
+
   /**
    * Memo-izes the related media items.
    */
@@ -450,11 +459,14 @@ const { data: { people = [] } = {}, loading: peopleLoading } = useLoader(onLoadP
           />
         )}
       </RecordDetailPanel>
-      { geometry && (
+      { geometryData && (
         <LocationMarkers
           animate
           boundingBoxOptions={boundingBoxOptions}
-          data={geometry}
+          buffer={geometryData.properties?.certainty_radius
+            ? kilometersToMiles(geometryData.properties?.certainty_radius)
+            : undefined}
+          data={geometryData.geometry}
           fillStyle={{
             type: 'fill',
             paint: {

--- a/src/apps/search/map/panels/Place.tsx
+++ b/src/apps/search/map/panels/Place.tsx
@@ -31,6 +31,17 @@ const Place = (props: Props) => {
     }
   }, [lang]);
 
+  const resolveGeometry = useCallback((place) => {
+    if (place?.place_geometry) {
+      return {
+        geometry: CoreDataUtils.toFeatureCollection([place]),
+        properties: place.place_geometry.properties
+      }
+    }
+
+    return null;
+  }, []);
+
   return (
     <BasePanel
       className={clsx('place', props.className)}
@@ -49,7 +60,7 @@ const Place = (props: Props) => {
         </>
       )}
       resolveDetailPageUrl={resolveDetailPageUrl}
-      resolveGeometry={(place) => place?.place_geometry && CoreDataUtils.toFeatureCollection([place])}
+      resolveGeometry={resolveGeometry}
       service={PlacesService}
     />
   );

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -35,3 +35,5 @@ export const parseFeature = (feature) => {
     properties
   };
 };
+
+export const kilometersToMiles = (km) => km * 0.621371;


### PR DESCRIPTION
# Summary

This PR updates the map search and the map on the detail page to support the new certainty radius feature by passing a value to the `buffer` prop on `LocationMarkers`. Since `LocationMarkers` expects the value to be in miles, I added a utility function to convert the `certainty_radius` from KM to miles.