### PR TITLE
Disable pulsing animation on points with certainty radius

### DIFF
--- a/src/apps/search/map/panels/BasePanel.tsx
+++ b/src/apps/search/map/panels/BasePanel.tsx
@@ -461,7 +461,7 @@ const { data: { people = [] } = {}, loading: peopleLoading } = useLoader(onLoadP
       </RecordDetailPanel>
       { geometryData && (
         <LocationMarkers
-          animate
+          animate={!geometryData.properties?.certainty_radius}
           boundingBoxOptions={boundingBoxOptions}
           buffer={geometryData.properties?.certainty_radius
             ? kilometersToMiles(geometryData.properties?.certainty_radius)


### PR DESCRIPTION
# Summary

When you click on a result in the map search to bring up the detail panel, points are given a pulsing animation. This was super ugly when combined with the certainty radius feature. This PR disables the animation when a certainty radius is present.