### PR TITLE
Saved searches restore an empty map on sites without preloaded geometry

### DIFF
--- a/src/apps/search/map/SaveButton.tsx
+++ b/src/apps/search/map/SaveButton.tsx
@@ -1,4 +1,3 @@
-import MapSearchContext from '@apps/search/map/MapSearchContext';
 import { useSearchConfig } from '@apps/search/SearchConfigContext';
 import { saveSession } from '@backend/api/session';
 import TranslationContext from '@contexts/TranslationContext';
@@ -10,7 +9,6 @@ import {
 } from '@performant-software/core-data';
 import NotificationsStore from '@store/notifications';
 import { useCallback, useContext, useState } from 'react';
-import _ from 'underscore';
 
 const SaveButton = () => {
   const [name, setName] = useState<string>();
@@ -20,7 +18,6 @@ const SaveButton = () => {
   const { name: searchName } = useSearchConfig();
   const hits = useCachedHits();
 
-  const { features } = useContext(MapSearchContext);
   const { t } = useContext(TranslationContext);
 
   /**
@@ -48,8 +45,7 @@ const SaveButton = () => {
 
     const data = {
       data: {
-        hits,
-        features: _.filter(features, (f) => f.properties.visible)
+        hits
       },
       name,
       searchName

--- a/src/visualizations/Map.tsx
+++ b/src/visualizations/Map.tsx
@@ -24,11 +24,25 @@ const Map = (props: DataVisualizationProps) => {
   const config = useMemo(() => parsed ? _.findWhere(runtimeConfig.search, { name: parsed.name }) : null, [parsed, runtimeConfig]);
 
   /**
-   * If the data set contains the features data, fetch the geometry for each.
+   * Builds features from Typesense hits when available — mirrors the live search
+   * page. Falls back to fetching geometry per feature only when hits are absent
+   * (legacy saved sessions on deployments that preload the geometry collection).
    */
   useEffect(() => {
-    if (parsed?.data?.features) {
-      const promises = _.map(parsed.data.features, ({ properties }) => (
+    if (!parsed?.data) {
+      return;
+    }
+
+    const { hits, features } = parsed.data;
+
+    if (hits && config?.map) {
+      const { geometry, properties } = config.map;
+      setFeatures(TypesenseUtils.getFeatures([], hits, geometry, properties));
+      return;
+    }
+
+    if (features) {
+      const promises = _.map(features, ({ properties }) => (
         fetchGeometry(properties.uuid)
           .then((data) => ({ data, properties }))
       ));
@@ -38,19 +52,7 @@ const Map = (props: DataVisualizationProps) => {
           setFeatures(_.map(values, ({ data, properties }) => _.extend(data, { properties })))
         ));
     }
-  }, [parsed]);
-
-  /**
-   * If the data set does not contain the features data, pull the geometry directly off the hits.
-   */
-  useEffect(() => {
-    if (parsed?.data && !parsed?.data?.features) {
-      const { hits } = parsed.data;
-      const { geometry, properties } = config.map;
-
-      setFeatures(TypesenseUtils.getFeatures([], hits, geometry, properties));
-    }
-  }, [parsed]);
+  }, [parsed, config]);
 
   return parsed && (
     <VisualizationContainer


### PR DESCRIPTION
## What

When a user restores a saved search, the map comes back empty — no place markers, no certainty radii. Affects any deployed CDP site that doesn't preload geometry (`PRELOAD_MAP=true`). List and timeline views work; only the map breaks.

## Why

`SaveButton` saves both `hits` and `features` into the session. On restore, the map sees `features` and tries to fetch each one's geometry from `/api/geometry/[uuid].json`. That endpoint is prerendered from the `geometry` content collection — but the collection is only registered when `PRELOAD_MAP=true`. On sites without the preload flag, every fetch returns 404 and the map renders nothing.

## Fix

- `Map.tsx` — build features directly from `hits`, the same way the live search page does. Fall back to per-feature `fetchGeometry` only when hits are absent (legacy saved sessions on preload-enabled sites).
- `SaveButton.tsx` — stop saving `features`; persist only `hits` and metadata.

Closes #616.

## Testing

- Save a fresh search, restore it, confirm markers render — including certainty radii where present.
- Live `/en/search/places/` and `/en/search/events/` views are unchanged.
