### PR TITLE
build.content.mjs: clone GITHUB_BRANCH instead of repo default

### DIFF
--- a/scripts/build.content.mjs
+++ b/scripts/build.content.mjs
@@ -13,9 +13,13 @@ export const fetchContent = async () => {
     fs.rmSync(TEMP_DIR, { recursive: true });
   }
 
-  // Clone the content repo into the temporary directory
+  // Clone the content repo into the temporary directory.
+  // Honor GITHUB_BRANCH so each Netlify env can read content from its own branch
+  // (e.g. staging from `develop`, prod from `main`). Default to `main` when unset.
   const url = `https://github.com/${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}.git`;
-  child_process.execSync(`git clone ${url} ${TEMP_DIR}`);
+  const branch = process.env.GITHUB_BRANCH || 'main';
+  console.log(`Cloning ${process.env.GITHUB_REPO}#${branch}`);
+  child_process.execFileSync('git', ['clone', '--branch', branch, '--single-branch', url, TEMP_DIR], { stdio: 'inherit' });
 
   // Copy the "content" folder to the current directory
   fs.cpSync(`${TEMP_DIR}/content`, './content', { recursive: true });


### PR DESCRIPTION
## Summary

- Pass `--branch ${GITHUB_BRANCH || 'main'} --single-branch` to `git clone` in `scripts/build.content.mjs` so each Netlify env can read content from its own branch (e.g. staging from `develop`, prod from `main`).
- Switch the underlying call from `execSync` (shell) to `execFileSync` (no shell) to remove any GITHUB_OWNER/_REPO/_BRANCH-derived shell-injection surface.
- Add a one-line clone-target log to help diagnose env-var drift in build logs.

## Why

Today TinaCMS reads `GITHUB_BRANCH` (`tina/database.ts:10-14`) and commits there, but the build script always cloned the repo's default branch. So setting `GITHUB_BRANCH=develop` on a Netlify site was silently ignored at build time, producing a TinaCMS-vs-build branch mismatch. This is the prerequisite for moving CDP content repos to a `main`-prod / `develop`-staging branch-per-env layout.

## Behavior change

Zero, while every existing site still sets `GITHUB_BRANCH=main`. Once a site flips to `develop` (a follow-up per-site migration), builds correctly pull `develop` content.

## Test plan

- [x] `npx vitest run test/config.test.ts` — 51/51 passed.
- [x] Local run with `GITHUB_BRANCH=main` against navigating-change-ghs-content — clones successfully.
- [x] Local run with `GITHUB_BRANCH=does-not-exist` — fails loudly (`fatal: Remote branch does-not-exist not found in upstream origin`) instead of silently falling back.
- [ ] Watch the next deploy on a fleet site (any one) build green; confirm log emits `Cloning <repo>#main`.