### PR TITLE
.env.example: document branch-per-env GITHUB_BRANCH pattern

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,12 @@ CONFIG_URL=https://raw.githubusercontent.com/...
 # If true, Netlify's CDN caching will be disabled
 DISABLE_CACHE=false
 
-# Name of the GitHub branch that will serve as the storage for TinaCMS content
-GITHUB_BRANCH=feature/tina
+# Name of the GitHub branch that will serve as the storage for TinaCMS content.
+# For multi-env deployments, set per-env: `develop` for staging, `main` for prod.
+# This way each env's TinaCMS commits land on its own branch and content
+# promotion (staging -> prod) is a deliberate `git merge develop main`.
+# Defaults to `main` if unset.
+GITHUB_BRANCH=develop
 
 # Name of the GitHub user or organization that owns the GitHub storage repository
 GITHUB_OWNER=owner-name


### PR DESCRIPTION
## Summary

- Update the `GITHUB_BRANCH` line in `.env.example` to recommend per-env values: `develop` for staging, `main` for prod.
- Documents the model where each Netlify env reads content from its own branch and content promotion (staging → prod) is a deliberate `git merge develop main`.
- No code change. Verified via `grep -rn 'config\.production\.json'` that the CDP build/runtime never references that file directly — the old "two files per branch" pattern is purely a content-repo convention, not a code one.

## Why

Staging→prod content promotion is infrequent and dev-driven, but today TinaCMS commits made via either env land on `main` and propagate. Branch-per-env gives each env its own write target. This PR is the documentation half of that move; the build-script half is in #624.

## Test plan

- [x] grep verification: zero references to `config.production.json` in the code repo (only the `.env.example` doc lines and content-repo conventions reference it).
- [ ] Per-site migration (Plan B) on each env to flip `GITHUB_BRANCH` and consolidate to one `config.json` per branch.