### PR TITLE
Raise Node heap limit for build to prevent OOM during TinaCMS indexing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,3 +22,7 @@
 
 [build.environment]
   NODE_VERSION = "22.13.0"
+  # TinaCMS content indexing (in `tinacms build`) and `astro build` both grow
+  # with content volume; on larger content repos they hit Node's ~2 GB default
+  # heap limit. Raise it so those steps don't OOM (V8 OOMs with "JavaScript heap out of memory", exit 134).
+  NODE_OPTIONS = "--max-old-space-size=4096"


### PR DESCRIPTION
## What

Adds `NODE_OPTIONS = "--max-old-space-size=4096"` to `netlify.toml` `[build.environment]`.

## Why

`tinacms build`'s content-indexing step (and `astro build`) grow with content volume. On larger content repos they exceed Node's ~2 GB default V8 heap limit and the build dies:

```
<--- Last few GCs --->
... Mark-Compact 2025.5 (2075.3) -> 2009.3 (2075.3) MB ... allocation failure
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
Failed during stage 'building site': Build script returned non-zero exit code: 2 (exit 134)
```

It's a V8 heap-limit OOM (not a container OOM-kill — Node was happily using 2 GB before its self-imposed limit stopped it), so raising `--max-old-space-size` is the right fix; the Netlify build image has well over 2 GB. 4096 clears it with margin and covers `tinacms build` and `astro build`. Local dev doesn't need it.

## Verification

Pushed on `rb/sso-fix` (PR #623) and confirmed all deploy previews go green, including the four that were OOMing on the prior commit: `gbof-c19nyc-staging`, `pss-scavenger-hunt`, `juel-ancestry`, `gamepossible` (plus `juel-life`, `juel-staging`, `libertos`, `registro-project`). Overall PR status flipped from failing to `success`.

## Notes

Split out from #623 so the build fix can land independently of the Clerk-auth changes there. (#623 is being reworked to require Clerk SSO; `tinacms-authjs`/username-password auth is broken on `develop` — see #626.)
