### PR TITLE
Fix posts/paths filter regression — only filter on `published` when drafts opt-in is set (closes #635)

### DIFF
--- a/src/pages/api/paths/index.json.ts
+++ b/src/pages/api/paths/index.json.ts
@@ -2,6 +2,7 @@ import { buildResponse } from '@utils/api';
 import { APIRoute } from 'astro';
 import { getPaths } from '@services/paths';
 import { convertToNumber } from '@utils/url';
+import config from '@config';
 
 export const GET: APIRoute = async (req) => {
   const params = req.url.searchParams.keys().reduce((acc, key) => ({
@@ -9,10 +10,14 @@ export const GET: APIRoute = async (req) => {
     [key]: convertToNumber(req.url.searchParams.get(key))
   }), {});
 
-  //enforcing published filter for all sites (is this what we want?)
-  let filter = {
-    published: { eq: true }
-  };
+  // Only filter on `published` when the site opts in via paths_config.drafts;
+  // otherwise existing paths (which don't carry the frontmatter field) disappear.
+  // See #635 — regression introduced when `publish` was renamed to `published`.
+  let filter: Record<string, unknown> = {};
+
+  if (config.content?.paths_config?.drafts) {
+    filter['published'] = { eq: true };
+  }
 
   if (params?.category) {
     filter['category'] = { eq: params.category };

--- a/src/pages/api/posts/index.json.ts
+++ b/src/pages/api/posts/index.json.ts
@@ -10,10 +10,14 @@ export const GET: APIRoute = async (req) => {
     [key]: convertToNumber(req.url.searchParams.get(key))
   }), {});
 
-  //enforcing published filter for all sites (is this what we want?)
-  let filter = {
-    published: { eq: true }
-  };
+  // Only filter on `published` when the site opts in via posts_config.drafts;
+  // otherwise existing posts (which don't carry the frontmatter field) disappear.
+  // See #635 — regression introduced when `publish` was renamed to `published`.
+  let filter: Record<string, unknown> = {};
+
+  if (config.content?.posts_config?.drafts) {
+    filter['published'] = { eq: true };
+  }
 
   if (params?.category) {
     filter['category'] = { eq: params.category };


### PR DESCRIPTION
Closes #635.

## Problem

`/api/posts/index.json` and `/api/paths/index.json` unconditionally filtered by `published: { eq: true }` since [1a71a82](https://github.com/performant-software/core-data-places/commit/1a71a82) (2026-03-20). Existing posts/paths in every tenant content repo don't carry that frontmatter field (the field was renamed from `publish` to `published` in the same commit). Result: every CDP site's `/en/posts` (and `/en/paths`) returns zero items.

Confirmed against `develop` on four staging sites (`juel-staging`, `juel-life`, `juel-ancestry`, `gbof-c19nyc-staging`) — all return `posts: []`. See #635 for full diagnosis.

## Fix

Restore the pre-2026-03-20 conditional shape in both endpoints, using the new `published` field name:

```ts
let filter: Record<string, unknown> = {};
if (config.content?.posts_config?.drafts) {
  filter['published'] = { eq: true };
}
```

Sites that opt into `posts_config.drafts: true` (or `paths_config.drafts: true`) still get the gated behavior; sites that don't see all posts/paths regardless of frontmatter — matching pre-regression behavior.

## Scope note

Issue #635 only mentions `/api/posts`, but the identical regression exists in `/api/paths/index.json.ts` from the same commit. Fixing both here.

## Verification

- `npx vitest run` → 51 passing, 4 skipped (no change).
- No new TypeScript errors beyond the pre-existing tolerated ones in this codebase (same `posts_config` literal-JSON narrowing as `PostList.tsx`, `tina/content/posts.ts`, etc.).
- After merge: smoke-test `/en/posts` on any affected staging site (e.g. `gbof-c19nyc.staging.performant.studio`) and confirm posts appear.

## Part of

v1.9.0 release tracker — #636.