### PR TITLE
Honor `GITHUB_BRANCH` when cloning content; add two defensive null guards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,12 @@ CONFIG_URL=https://raw.githubusercontent.com/...
 # If true, Netlify's CDN caching will be disabled
 DISABLE_CACHE=false
 
-# Name of the GitHub branch that will serve as the storage for TinaCMS content
-GITHUB_BRANCH=feature/tina
+# Name of the GitHub branch that will serve as the storage for TinaCMS content.
+# For multi-env deployments, set per-env: `develop` for staging, `main` for prod.
+# This way each env's TinaCMS commits land on its own branch and content
+# promotion (staging -> prod) is a deliberate `git merge develop main`.
+# Defaults to `main` if unset.
+GITHUB_BRANCH=develop
 
 # Name of the GitHub user or organization that owns the GitHub storage repository
 GITHUB_OWNER=owner-name

--- a/scripts/build.content.mjs
+++ b/scripts/build.content.mjs
@@ -13,9 +13,13 @@ export const fetchContent = async () => {
     fs.rmSync(TEMP_DIR, { recursive: true });
   }
 
-  // Clone the content repo into the temporary directory
+  // Clone the content repo into the temporary directory.
+  // Honor GITHUB_BRANCH so each Netlify env can read content from its own branch
+  // (e.g. staging from `develop`, prod from `main`). Default to `main` when unset.
   const url = `https://github.com/${process.env.GITHUB_OWNER}/${process.env.GITHUB_REPO}.git`;
-  child_process.execSync(`git clone ${url} ${TEMP_DIR}`);
+  const branch = process.env.GITHUB_BRANCH || 'main';
+  console.log(`Cloning ${process.env.GITHUB_REPO}#${branch}`);
+  child_process.execFileSync('git', ['clone', '--branch', branch, '--single-branch', url, TEMP_DIR], { stdio: 'inherit' });
 
   // Copy the "content" folder to the current directory
   fs.cpSync(`${TEMP_DIR}/content`, './content', { recursive: true });

--- a/src/apps/posts/PlaceInsert.tsx
+++ b/src/apps/posts/PlaceInsert.tsx
@@ -7,6 +7,10 @@ import React, { useMemo } from 'react';
 const PlaceInsert = (props: any) => {
   const { selection, setSelection } = useSelectionState();
 
+  if (!props.place?.uuid) {
+    return null;
+  }
+
   /**
    * Memo-izes the properties of the selected feature.
    */

--- a/src/visualizations/Timeline.tsx
+++ b/src/visualizations/Timeline.tsx
@@ -5,7 +5,11 @@ import React, { useMemo } from 'react';
 import _ from 'underscore';
 
 const TimelineVisualization = (props: DataVisualizationProps) => {
-  
+
+  if (!props.data) {
+    return null;
+  }
+
   /**
    * Memo-izes the "data" prop as JSON.
    */


### PR DESCRIPTION
## What

Two small, independent improvements:

**Branch-per-environment content cloning.** `scripts/build.content.mjs` now honors `GITHUB_BRANCH` when cloning the content repo. Previously it always cloned the default branch, so a project couldn't keep a separate content branch per deployed environment (for example, `develop` for staging and `main` for production). `.env.example` documents the pattern.

**Two defensive null guards.** Render nothing when a required prop is missing:
- `src/apps/posts/PlaceInsert.tsx` — guards against an unsaved insert in the TinaCMS preview (`place.uuid` not yet set).
- `src/visualizations/Timeline.tsx` — guards against an empty `data` prop.

Both null guards surfaced as runtime crashes during content-editing on marronage staging.

## Testing

`npx vitest run` — 51 passing.

Refs #636.
