### PR TITLE
Document and ship the v1.9.0 posts/paths frontmatter migration

### DIFF
--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -21,6 +21,34 @@ Background: the username/password path was broken by an upstream incompatibility
 
 If the Clerk env vars are missing, the build fails fast with a clear error. Local development is unchanged: set `TINA_PUBLIC_IS_LOCAL=true` and no Clerk config is needed.
 
+### Posts and paths need `published: true` in frontmatter
+
+`1.9.0` ties the public posts and paths feeds (`/api/posts`, `/api/paths`) to a draft / published workflow that is shared with the Clerk roles logic — editors see drafts, the public sees only published content. The feeds filter unconditionally by `published: true`, so any existing `.mdx` file in the tenant content repo whose frontmatter predates this rename will stop appearing on the upgraded site until it is migrated.
+
+The migration is a one-line frontmatter change per post and path. Either:
+
+- Rename the old `publish:` key to `published:` (value preserved), or
+- Add `published: true` if no publish key is present.
+
+```yaml
+---
+title: "…"
+published: true   # add this (or rename the old `publish:` key)
+---
+```
+
+For sites with only a handful of posts and paths, edit them in TinaCMS or by hand. For larger content sets, run the included migration script against a checkout of the content repo:
+
+```bash
+node scripts/migrations/v1.9.0-posts-published.mjs \
+  /path/to/content-repo/content/posts \
+  /path/to/content-repo/content/paths
+```
+
+The script does a surgical line-level edit so TinaCMS's frontmatter formatting is preserved exactly. It is idempotent (running twice is a no-op) and handles both the rename case and the add case automatically. Open a PR against the tenant content repo with the result, merge, then redeploy the site.
+
+If a future project genuinely needs Clerk auth without the publish workflow, that is a separate design conversation — out of scope for this release.
+
 ## 1.6.0
 
 ### Embedded maps

--- a/scripts/migrations/v1.9.0-posts-published.mjs
+++ b/scripts/migrations/v1.9.0-posts-published.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// v1.9.0 posts/paths frontmatter migration.
+//
+// CDP v1.9.0 filters posts and paths unconditionally by `published: true`.
+// Tenant content that predates this rename either has the old `publish:` key
+// or no publish key at all. This script does a surgical line-level edit per
+// file so TinaCMS's frontmatter formatting is preserved:
+//
+//   - If `published:` already present → no-op.
+//   - Else if `publish:` present     → rename `publish:` → `published:` (value preserved).
+//   - Else                            → append `published: true` to the frontmatter block.
+//
+// Idempotent — running twice is a no-op.
+//
+// Usage:  node scripts/migrations/v1.9.0-posts-published.mjs <dir> [<dir>...]
+// Example (against a checked-out tenant content repo):
+//   node scripts/migrations/v1.9.0-posts-published.mjs \
+//     ../tenant-content/content/posts \
+//     ../tenant-content/content/paths
+//
+// See docs/upgrade-notes.md § 1.9.0 for context.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const dirs = process.argv.slice(2);
+if (dirs.length === 0) {
+  console.error('Usage: node scripts/migrations/v1.9.0-posts-published.mjs <dir> [<dir>...]');
+  process.exit(1);
+}
+
+const totals = { renamed: 0, added: 0, alreadyMigrated: 0, noFrontmatter: 0, notMdx: 0 };
+
+for (const dir of dirs) {
+  if (!fs.existsSync(dir)) {
+    console.error(`SKIP dir (does not exist): ${dir}`);
+    continue;
+  }
+  const stats = { dir, renamed: 0, added: 0, alreadyMigrated: 0, noFrontmatter: 0 };
+  const entries = fs.readdirSync(dir);
+  for (const name of entries) {
+    if (!name.endsWith('.mdx')) { totals.notMdx++; continue; }
+    const full = path.join(dir, name);
+    const content = fs.readFileSync(full, 'utf8');
+
+    // Frontmatter block: leading '---\n', body, trailing '\n---\n' (or end-of-file '\n---').
+    const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
+    if (!match) {
+      console.warn(`  no frontmatter: ${name}`);
+      stats.noFrontmatter++;
+      totals.noFrontmatter++;
+      continue;
+    }
+    const fmBlock = match[0];
+    const fmBody = match[1];
+    const trailing = match[2]; // '\n', '\r\n', or ''
+
+    let newFmBody;
+    if (/^published:\s/m.test(fmBody)) {
+      stats.alreadyMigrated++;
+      totals.alreadyMigrated++;
+      continue;
+    } else if (/^publish:\s/m.test(fmBody)) {
+      newFmBody = fmBody.replace(/^publish:(\s)/m, 'published:$1');
+      stats.renamed++;
+      totals.renamed++;
+    } else {
+      newFmBody = fmBody + '\npublished: true';
+      stats.added++;
+      totals.added++;
+    }
+
+    const newFmBlock = `---\n${newFmBody}\n---${trailing}`;
+    const newContent = content.replace(fmBlock, newFmBlock);
+    fs.writeFileSync(full, newContent);
+  }
+  console.log(`${dir}: ${JSON.stringify(stats)}`);
+}
+
+console.log('\nTotals:', JSON.stringify(totals, null, 2));


### PR DESCRIPTION
## Summary

Ships the v1.9.0 posts/paths content migration as a reusable script (`scripts/migrations/v1.9.0-posts-published.mjs`) and documents the upgrade step under `## 1.9.0` in `docs/upgrade-notes.md`. Closes the last pre-release item on #636.

## Why

v1.9.0 filters `/api/posts` and `/api/paths` unconditionally by `published: true`. Existing tenant content predates that field, so a per-site migration is required on upgrade. The script does surgical line-level edits — renaming an old `publish:` key or adding `published: true` — so TinaCMS frontmatter formatting is preserved. Idempotent.

Already used against the three JUEL content repos: performant-software/juel-staging-content#5 (73-post rename), performant-software/juel-ancestry-content#1 and performant-software/juel-life-content#1 (5 posts each, add path).

Refs #635.