### PR TITLE
Fix JSON-embed round-trip in posts: search export → TinaCMS upload → rich-text render

### DIFF
--- a/src/apps/posts/PlaceInsert.tsx
+++ b/src/apps/posts/PlaceInsert.tsx
@@ -7,10 +7,6 @@ import React, { useMemo } from 'react';
 const PlaceInsert = (props: any) => {
   const { selection, setSelection } = useSelectionState();
 
-  if (!props.place?.uuid) {
-    return null;
-  }
-
   /**
    * Memo-izes the properties of the selected feature.
    */

--- a/src/apps/search/map/ExportButton.tsx
+++ b/src/apps/search/map/ExportButton.tsx
@@ -14,16 +14,16 @@ const ExportButton = () => {
   const { name } = useSearchConfig();
   const { t } = useContext(TranslationContext);
 
-  const { features } = useContext(MapSearchContext);
+  const { features, hits } = useContext(MapSearchContext);
 
   /**
    * Exports the current search results in the passed format.
    */
   const onSelection = useCallback((option) => {
     if (option === Options.json) {
-      exportAsJSON({ name, data: { features } });
+      exportAsJSON({ name, data: { features, hits } });
     }
-  }, [name, features]);
+  }, [name, features, hits]);
 
   return (
     <Listbox

--- a/src/apps/search/map/MapSearchContext.tsx
+++ b/src/apps/search/map/MapSearchContext.tsx
@@ -43,6 +43,7 @@ interface SearchContextType {
   features: Feature[];
   getBoundingBox(): Promise<LngLatBoundsLike>;
   getGeometry(id: string): Feature;
+  hits: any[];
   layerType: typeof LayerTypes.single | typeof LayerTypes.multiple;
   setBoundingBoxOptions(boundingBoxOptions: BoundingBoxOptions): void;
   setControlsClass(controlsClass: string): void;
@@ -171,6 +172,7 @@ export const MapSearchContextProvider = ({ allowSave, children, preload }: Props
         features,
         getBoundingBox,
         getGeometry,
+        hits,
         layerType,
         setBoundingBoxOptions,
         setControlsClass

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -5,11 +5,42 @@ import {
   OverlayLayers,
   Peripleo as PeripleoUtils
 } from '@performant-software/core-data';
-import { Map as PeripleoMap, ZoomControl } from '@peripleo/maplibre';
-import { useRuntimeConfig } from '@peripleo/peripleo';
+import { Map as PeripleoMap, useLoadedMap, ZoomControl } from '@peripleo/maplibre';
+import { MapProvider, useRuntimeConfig } from '@peripleo/peripleo';
 import clsx from 'clsx';
-import { type ReactNode, useContext, useMemo, useState } from 'react';
+import { type ReactNode, useContext, useEffect, useMemo, useState } from 'react';
 import _ from 'underscore';
+
+/**
+ * Defers rendering children until the underlying MapLibre style has fully
+ * loaded. Peripleo's `useLoadedMap` returns the map synchronously the moment a
+ * style prop is provided to `<PeripleoMap>`, even though MapLibre hasn't
+ * finished parsing the style yet. Layer-adding children (e.g. `LocationMarkers`
+ * via `GeoJSONLayer`) then call `map.getStyle().layers` and crash because the
+ * style is undefined. Gating on `isStyleLoaded()` and the `styledata` /`load`
+ * events avoids that race.
+ */
+const WhenStyleLoaded = ({ children }: { children: ReactNode }) => {
+  const map = useLoadedMap() as any;
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!map) return;
+    if (typeof map.isStyleLoaded === 'function' && map.isStyleLoaded()) {
+      setReady(true);
+      return;
+    }
+    const onReady = () => setReady(true);
+    map.once?.('styledata', onReady);
+    map.once?.('load', onReady);
+    return () => {
+      map.off?.('styledata', onReady);
+      map.off?.('load', onReady);
+    };
+  }, [map]);
+
+  return ready ? <>{children}</> : null;
+};
 
 interface Props {
   children: ReactNode,
@@ -43,39 +74,49 @@ const Map = (props: Props) => {
     'hover:opacity-90'
   ].join(' '), []);
 
+  // Each BaseMap gets its own MapProvider. Peripleo ships a single shared
+  // `MapContext` at the app root, so when a post body contains more than one
+  // map (e.g. a `<place>` block and a `<map>` block), each PeripleoMap mount
+  // overwrites the previous one's `setMap(...)` and `useLoadedMap()` returns
+  // the wrong instance for the earlier subtree. Isolating the context per
+  // BaseMap avoids the cross-contamination.
   return (
-    <PeripleoMap
-      attributionControl={false}
-      className={clsx('grow', props.classNames?.root)}
-      style={PeripleoUtils.toLayerStyle(baseLayer, baseLayer.name)}
-    >
-      <div
-        className={clsx('absolute top-0 right-0 flex flex-col py-3 px-3 gap-y-2', props.classNames?.controls)}
+    <MapProvider>
+      <PeripleoMap
+        attributionControl={false}
+        className={clsx('grow', props.classNames?.root)}
+        style={PeripleoUtils.toLayerStyle(baseLayer, baseLayer.name)}
       >
-        <ZoomControl
-          zoomIn={<Icon name='zoom_in' />}
-          zoomInProps={{ className: buttonClass }}
-          zoomOut={<Icon name='zoom_out' />}
-          zoomOutProps={{ className: buttonClass }}
-        />
-        { [...baseLayers, ...dataLayers].length > 1 && (
-          <LayerMenu
-            baseLayer={baseLayer?.name}
-            baseLayers={baseLayers}
-            baseLayersLabel={t('baseLayers')}
-            className={buttonClass}
-            dataLayers={dataLayers}
-            onChangeBaseLayer={setBaseLayer}
-            onChangeOverlays={setOverlays}
-            overlaysLabel={t('overlays')}
+        <div
+          className={clsx('absolute top-0 right-0 flex flex-col py-3 px-3 gap-y-2', props.classNames?.controls)}
+        >
+          <ZoomControl
+            zoomIn={<Icon name='zoom_in' />}
+            zoomInProps={{ className: buttonClass }}
+            zoomOut={<Icon name='zoom_out' />}
+            zoomOutProps={{ className: buttonClass }}
           />
-        )}
-      </div>
-      <OverlayLayers
-        overlays={overlays}
-      />
-      { props.children }
-    </PeripleoMap>
+          { [...baseLayers, ...dataLayers].length > 1 && (
+            <LayerMenu
+              baseLayer={baseLayer?.name}
+              baseLayers={baseLayers}
+              baseLayersLabel={t('baseLayers')}
+              className={buttonClass}
+              dataLayers={dataLayers}
+              onChangeBaseLayer={setBaseLayer}
+              onChangeOverlays={setOverlays}
+              overlaysLabel={t('overlays')}
+            />
+          )}
+        </div>
+        <WhenStyleLoaded>
+          <OverlayLayers
+            overlays={overlays}
+          />
+          { props.children }
+        </WhenStyleLoaded>
+      </PeripleoMap>
+    </MapProvider>
   );
 };
 

--- a/src/utils/visualization.ts
+++ b/src/utils/visualization.ts
@@ -21,11 +21,24 @@ export const buildMapData = (config: SearchConfig, data: any) => {
   return {
     data: {
       features,
-      hits
+      hits: _.map(hits, sanitizeHit)
     },
     name: config.name
   };
 };
+
+/**
+ * Strips Algolia-style decoration fields (`_highlightResult`, `_snippetResult`,
+ * `_rankingInfo`) from a hit. These fields store HTML-pre-escaped snippets
+ * containing literal entity strings like `&quot;`; TinaCMS's MDX attribute
+ * serializer encodes `"` as `&#x22;` but does not encode `&`, so any `&quot;`
+ * in saved JSON round-trips to an unescaped `"`, corrupting the JSON. Beyond
+ * the round-trip safety, the decoration fields are not used by any
+ * visualization renderer and roughly triple the saved payload size.
+ */
+const sanitizeHit = (hit: any) => (
+  _.omit(hit, '_highlightResult', '_snippetResult', '_rankingInfo')
+);
 
 /**
  * Returns the data for the table visualization.

--- a/src/visualizations/EventsByYear.tsx
+++ b/src/visualizations/EventsByYear.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
   ResponsiveContainer
 } from 'recharts';
+import { parseVisualizationData } from './parseData';
 
 interface Props extends DataVisualizationProps {
   interval: number;
@@ -23,7 +24,7 @@ const EventsByYear = (props: Props) => {
   /**
    * Memo-izes the data as parsed JSON.
   */
-  const data = useMemo(() => props.data ? JSON.parse(props.data) : null, [props.data]);
+  const data = useMemo(() => parseVisualizationData(props.data), [props.data]);
 
   return data && (
     <VisualizationContainer

--- a/src/visualizations/EventsByYear.tsx
+++ b/src/visualizations/EventsByYear.tsx
@@ -20,10 +20,6 @@ const DEFAULT_INTERVAL = 10;
 const EventsByYear = (props: Props) => {
   const { interval = DEFAULT_INTERVAL } = props;
 
-  if (!props.data) {
-    return null;
-  }
-
   /**
    * Memo-izes the data as parsed JSON.
   */

--- a/src/visualizations/Map.tsx
+++ b/src/visualizations/Map.tsx
@@ -7,6 +7,7 @@ import { useRuntimeConfig } from '@peripleo/peripleo';
 import type { Configuration, DataVisualizationProps } from '@types';
 import React, { useEffect, useId, useMemo, useState } from 'react';
 import _ from 'underscore';
+import { parseVisualizationData } from './parseData';
 
 const Map = (props: DataVisualizationProps) => {
   const [features, setFeatures] = useState([]);
@@ -16,7 +17,7 @@ const Map = (props: DataVisualizationProps) => {
   /**
    * Memo-izes the "data" prop as JSON.
    */
-  const parsed = useMemo(() => props.data ? JSON.parse(props.data) : null, [props.data]);
+  const parsed = useMemo(() => parseVisualizationData(props.data), [props.data]);
 
   /**
    * Memo-izes the search config based on the data set.

--- a/src/visualizations/Map.tsx
+++ b/src/visualizations/Map.tsx
@@ -5,17 +5,13 @@ import { Typesense as TypesenseUtils } from '@performant-software/core-data';
 import { LocationMarkers, Map as MapUtils } from '@performant-software/geospatial';
 import { useRuntimeConfig } from '@peripleo/peripleo';
 import type { Configuration, DataVisualizationProps } from '@types';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useId, useMemo, useState } from 'react';
 import _ from 'underscore';
 
 const Map = (props: DataVisualizationProps) => {
   const [features, setFeatures] = useState([]);
-
-  if (!props.data) {
-    return null;
-  }
-
   const runtimeConfig = useRuntimeConfig<Configuration>();
+  const layerId = useId();
 
   /**
    * Memo-izes the "data" prop as JSON.
@@ -70,6 +66,7 @@ const Map = (props: DataVisualizationProps) => {
             <LocationMarkers
               boundingBoxOptions={{ padding: 20 }}
               data={MapUtils.toFeatureCollection(features)}
+              layerId={layerId}
             />
           </BaseMap> 
         )}

--- a/src/visualizations/StackedTimeline.tsx
+++ b/src/visualizations/StackedTimeline.tsx
@@ -46,10 +46,6 @@ const CustomTooltip = ({ active, payload, label }: TooltipContentProps<string | 
 const StackedTimeline = (props: Props) => {
   const { link, model, filter } = props;
 
-  if (!props.data) {
-    return null;
-  }
-  
   /**
    * Memo-izes the data as parsed JSON.
   */

--- a/src/visualizations/StackedTimeline.tsx
+++ b/src/visualizations/StackedTimeline.tsx
@@ -16,6 +16,7 @@ import {
 import config from '@config' with { type: 'json' };
 import _ from 'underscore';
 import { hasDetailPage } from '@utils/detailPagePaths';
+import { parseVisualizationData } from './parseData';
 
 interface Props extends DataVisualizationProps {
   link?: string;
@@ -49,7 +50,7 @@ const StackedTimeline = (props: Props) => {
   /**
    * Memo-izes the data as parsed JSON.
   */
- const data = useMemo(() => props.data ? JSON.parse(props.data) : null, [props.data]);
+ const data = useMemo(() => parseVisualizationData(props.data), [props.data]);
 
  const language = useMemo(() => getLanguageFromUrl(window.location.pathname), [window.location.pathname]);
 

--- a/src/visualizations/Table.tsx
+++ b/src/visualizations/Table.tsx
@@ -8,14 +8,10 @@ import _ from 'underscore';
 const Table = (props: DataVisualizationProps) => {
   const { t } = useContext(TranslationContext);
 
-  if (!props.data) {
-    return null;
-  }
-
   /**
    * Memo-izes the data as JSON.
    */
-  const { data } = useMemo(() => props.data ? JSON.parse(props.data) : null, [props.data]);
+  const { data } = useMemo(() => (props.data ? JSON.parse(props.data) : { data: null }), [props.data]);
 
   /**
    * Memo-izes the table columns and labels.

--- a/src/visualizations/Table.tsx
+++ b/src/visualizations/Table.tsx
@@ -4,6 +4,7 @@ import { SearchResultsTable } from '@performant-software/core-data';
 import type { DataVisualizationProps } from '@types';
 import { useContext, useMemo } from 'react';
 import _ from 'underscore';
+import { parseVisualizationData } from './parseData';
 
 const Table = (props: DataVisualizationProps) => {
   const { t } = useContext(TranslationContext);
@@ -11,7 +12,7 @@ const Table = (props: DataVisualizationProps) => {
   /**
    * Memo-izes the data as JSON.
    */
-  const { data } = useMemo(() => (props.data ? JSON.parse(props.data) : { data: null }), [props.data]);
+  const { data } = useMemo(() => parseVisualizationData(props.data) ?? { data: null }, [props.data]);
 
   /**
    * Memo-izes the table columns and labels.

--- a/src/visualizations/Timeline.tsx
+++ b/src/visualizations/Timeline.tsx
@@ -3,12 +3,13 @@ import { Timeline, Typesense as TypesenseUtils } from '@performant-software/core
 import type { DataVisualizationProps } from '@types';
 import React, { useMemo } from 'react';
 import _ from 'underscore';
+import { parseVisualizationData } from './parseData';
 
 const TimelineVisualization = (props: DataVisualizationProps) => {
   /**
    * Memo-izes the "data" prop as JSON.
    */
-  const data = useMemo(() => props.data ? JSON.parse(props.data) : null, [props.data]);
+  const data = useMemo(() => parseVisualizationData(props.data), [props.data]);
 
   /**
    * Memo-izes the events and sets the "date" attribute.

--- a/src/visualizations/Timeline.tsx
+++ b/src/visualizations/Timeline.tsx
@@ -5,11 +5,6 @@ import React, { useMemo } from 'react';
 import _ from 'underscore';
 
 const TimelineVisualization = (props: DataVisualizationProps) => {
-
-  if (!props.data) {
-    return null;
-  }
-
   /**
    * Memo-izes the "data" prop as JSON.
    */

--- a/src/visualizations/parseData.ts
+++ b/src/visualizations/parseData.ts
@@ -1,0 +1,22 @@
+/**
+ * Parses a JSON string from a TinaCMS rich-text embed's `data` attribute.
+ *
+ * Returns `null` for empty input and also for any JSON.parse error. A render-
+ * side parse failure indicates corrupted data — typically from MDX attribute
+ * round-trip artifacts (e.g. literal `&quot;` strings in highlight snippets
+ * being decoded to unescaped `"`). The visualization components gate their
+ * render on a truthy result, so returning `null` renders nothing instead of
+ * propagating an uncaught exception that would crash the editor iframe.
+ */
+export const parseVisualizationData = (data: string | null | undefined): any => {
+  if (!data) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(data);
+  } catch (err) {
+    console.error('Visualization data failed to parse; embed will not render.', err);
+    return null;
+  }
+};

--- a/test/visualization.test.ts
+++ b/test/visualization.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { buildTimelineData } from '../src/utils/visualization';
+
+describe('buildTimelineData', () => {
+  const eventsSearchConfig = {
+    name: 'events',
+    timeline: { date_range_facet: 'start_year_facet' }
+  } as any;
+
+  it('returns empty events when the export has only features (reproduces #645)', () => {
+    const data = {
+      features: [
+        {
+          type: 'Feature',
+          properties: { uuid: 'abc', title: 'Anaya Hato Enclave', name: 'Anaya Hato Enclave' },
+          geometry: { type: 'Point', coordinates: [-77.13, 17.91] }
+        }
+      ]
+    };
+
+    const result = buildTimelineData(eventsSearchConfig, data);
+
+    expect(result.name).toBe('events');
+    expect(result.events).toHaveLength(0);
+  });
+
+  it('populates events from hits when the export includes hits (fix verification)', () => {
+    const data = {
+      features: [
+        {
+          type: 'Feature',
+          properties: { uuid: 'abc', name: 'Battle of Chuao' },
+          geometry: { type: 'Point', coordinates: [-67.5, 10.7] }
+        }
+      ],
+      hits: [
+        { name: 'Battle of Chuao', start_date: [-5500000000], end_date: [-5400000000] },
+        { name: 'Settlement Founded', start_date: [-5000000000], end_date: [-4900000000] }
+      ]
+    };
+
+    const result = buildTimelineData(eventsSearchConfig, data);
+
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0]).toMatchObject({ name: 'Battle of Chuao' });
+    expect(result.events[1]).toMatchObject({ name: 'Settlement Founded' });
+  });
+});

--- a/test/visualization.test.ts
+++ b/test/visualization.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildTimelineData } from '../src/utils/visualization';
+import { buildMapData, buildTimelineData } from '../src/utils/visualization';
 
 describe('buildTimelineData', () => {
   const eventsSearchConfig = {
@@ -44,5 +44,63 @@ describe('buildTimelineData', () => {
     expect(result.events).toHaveLength(2);
     expect(result.events[0]).toMatchObject({ name: 'Battle of Chuao' });
     expect(result.events[1]).toMatchObject({ name: 'Settlement Founded' });
+  });
+});
+
+describe('buildMapData', () => {
+  const placesSearchConfig = { name: 'places' } as any;
+
+  it('strips Algolia decoration fields from hits so the saved JSON round-trips through MDX attributes', () => {
+    const data = {
+      features: [
+        {
+          type: 'Feature',
+          properties: { uuid: 'abc', name: 'Cockpit Country' },
+          geometry: { type: 'Point', coordinates: [-77.5, 18.3] }
+        }
+      ],
+      hits: [
+        {
+          id: '1',
+          uuid: 'abc',
+          name: 'Cockpit Country',
+          _highlightResult: {
+            description: { value: 'enslaved &quot;recent arrivals&quot;', matchLevel: 'none', matchedWords: [] }
+          },
+          _snippetResult: {
+            description: { value: 'enslaved &quot;recent arrivals&quot;', matchLevel: 'none' }
+          },
+          _rankingInfo: { nbTypos: 0 }
+        }
+      ]
+    };
+
+    const result = buildMapData(placesSearchConfig, data);
+
+    expect(result.data.hits).toHaveLength(1);
+    expect(result.data.hits[0]).not.toHaveProperty('_highlightResult');
+    expect(result.data.hits[0]).not.toHaveProperty('_snippetResult');
+    expect(result.data.hits[0]).not.toHaveProperty('_rankingInfo');
+    expect(result.data.hits[0]).toMatchObject({ id: '1', uuid: 'abc', name: 'Cockpit Country' });
+
+    // No HTML-entity-like sequences remain in the serialized form, so MDX
+    // attribute serialization will round-trip cleanly.
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toMatch(/&[a-zA-Z0-9#]+;/);
+  });
+
+  it('preserves features unchanged', () => {
+    const features = [
+      {
+        type: 'Feature',
+        properties: { uuid: 'abc' },
+        geometry: { type: 'Point', coordinates: [0, 0] }
+      }
+    ];
+
+    const result = buildMapData(placesSearchConfig, { features, hits: [] });
+
+    expect(result.data.features).toEqual(features);
+    expect(result.name).toBe('places');
   });
 });

--- a/tina/components/JsonUpload.tsx
+++ b/tina/components/JsonUpload.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 const JsonUpload = (props: Props) => {
   const [error, setError] = useState(null);
-  const inputRef = useRef();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   /**
    * Memo-izes the value as JSON.
@@ -28,6 +28,8 @@ const JsonUpload = (props: Props) => {
     const { current: instance } = inputRef;
 
     if (instance) {
+      // Reset the value so re-selecting the same file still fires onChange
+      instance.value = '';
       instance.click();
     }
   }, []);

--- a/tina/utils/visualizations.ts
+++ b/tina/utils/visualizations.ts
@@ -1,8 +1,14 @@
 import _ from 'underscore';
 
 /**
- * Returns true if the timeline embed is available for the passed search configuration.
+ * Returns true if the `<timeline>` post embed is available for the passed search
+ * configuration. The embed needs `timeline.event_path` because
+ * `buildTimelineData` extracts events via `getNestedValue(hit, event_path)`;
+ * without it, the build returns zero events.
  *
- * @param config
+ * This is distinct from the search-UI timeline view (the "Timeline" toggle on
+ * the search page), which is gated on `timeline.date_range_facet` in
+ * `Header.tsx` / `TimelineView.tsx`. A search can enable that filter without
+ * also enabling the post embed.
  */
-export const includeTimeline = (config) => !_.isEmpty(config.timeline);
+export const includeTimeline = (config) => !_.isEmpty(config?.timeline?.event_path);


### PR DESCRIPTION
## Summary

Closes #645. JSON exports from a search can now be embedded in posts via TinaCMS without crashing the visual editor.

The investigation started as a one-line fix for the timeline upload and kept finding the next bug in the same data flow. Result is two thematic commits — keep them separate; reviewers can read either independently.

### Export-side

The map search exports `{ data: { features } }`, but the timeline / table / stacked-timeline parsers all read `data.hits`. Uploads silently produced empty events and rows.

- Expose `hits` on `MapSearchContext` and include it in the export payload alongside `features`. The map import (reads `data.features`) is unaffected.
- Reset `JsonUpload`'s hidden file input on click so re-selecting the same file fires `change` instead of silently no-op'ing.

### Render-side

Once uploads carried real data, several latent bugs surfaced on the render path:

- **Rules-of-Hooks** in all five visualization components (`Map`, `Timeline`, `StackedTimeline`, `Table`, `EventsByYear`) and in `PlaceInsert`. Each called hooks both before and after `if (!props.data) return null`, so the hook count jumped on the empty → data transition. Hoisted hooks above the gate; the existing JSX-level `data && (...)` gates already cover the no-data case.
- **Missing `layerId`** on the visualization `<Map>`. Without it, Peripleo's `GeoJSONLayer` built layer keys like `layer-undefined-point`. Now passed a stable id via `useId()`.
- **Shared `MapContext` across multiple maps.** Peripleo wraps the app in a single `<MapProvider>`. When a post has more than one `<BaseMap>` (e.g. a `<place>` block plus a `<map>` block), each `<PeripleoMap>` mount overwrites the previous `setMap(...)`, and `useLoadedMap()` returns the wrong map for the earlier subtree. Each `<BaseMap>` now wraps its own `<MapProvider>` so the context is per-instance.
- **`<WhenStyleLoaded>` gate** in `BaseMap`. Belt-and-suspenders for the case where the shared-context bug above hands a child a map whose style hasn't finished loading. Defers layer-adding children until `isStyleLoaded()` or the `styledata`/`load` events.

## Test plan

- [ ] Export from a timeline-eligible search; confirm the file has `data.features` and `data.hits`.
- [ ] Add a Timeline block to a post, upload the file, confirm the stored payload's `events` array is populated.
- [ ] Re-click Upload with the same file; confirm the change handler fires.
- [ ] Add a `<map>` block to a post that already contains a `<place>` block; upload a places JSON; confirm both maps render with no console errors.
- [ ] Confirm the live search page map still works (it reads `data.features`).