### PR TITLE
Contain post-embed crashes so removing a map doesn't kill the editor

### DIFF
--- a/src/apps/posts/PostContent.tsx
+++ b/src/apps/posts/PostContent.tsx
@@ -1,6 +1,7 @@
 import PlaceInsert from '@apps/posts/PlaceInsert';
 import IframeEmbed from '@components/IframeEmbed';
 import MediaInsert from '@components/MediaInsert'
+import PostEmbedErrorBoundary from '@components/PostEmbedErrorBoundary';
 import TranslationContext from '@contexts/TranslationContext';
 import { useTranslations } from '@i18n/useTranslations';
 import { Peripleo as PeripleoUtils } from '@performant-software/core-data';
@@ -45,19 +46,24 @@ const PostContent = (props: PostContentProps) => {
               className='prose prose-lg max-w-none w-full'
               data-tina-field={tinaField(data?.post)}
             >
-              <TinaMarkdown
-                components={{
-                  data_table: Table,
-                  events_by_year: EventsByYear,
-                  iframe: IframeEmbed,
-                  map: Map,
-                  media: MediaInsert,
-                  place: PlaceInsert,
-                  stacked_timeline: StackedTimeline,
-                  timeline: Timeline
-                }}
-                content={data?.post?.body}
-              />
+              <PostEmbedErrorBoundary
+                resetKeys={[data?.post?.body]}
+                fallback={<p className='italic text-sm'>{t('embedRenderError')}</p>}
+              >
+                <TinaMarkdown
+                  components={{
+                    data_table: Table,
+                    events_by_year: EventsByYear,
+                    iframe: IframeEmbed,
+                    map: Map,
+                    media: MediaInsert,
+                    place: PlaceInsert,
+                    stacked_timeline: StackedTimeline,
+                    timeline: Timeline
+                  }}
+                  content={data?.post?.body}
+                />
+              </PostEmbedErrorBoundary>
             </article>
           </div>
         </TranslationContext.Provider>

--- a/src/apps/posts/PostContent.tsx
+++ b/src/apps/posts/PostContent.tsx
@@ -30,6 +30,16 @@ const PostContent = (props: PostContentProps) => {
     data: props.data,
   });
 
+  // The embed fallback is, in practice, only hit in the TinaCMS visual editor
+  // (the preview renders inside its iframe). Reassure the editor that edits are
+  // safe; show a neutral message on a normally-loaded published page.
+  const isEditing = typeof window !== 'undefined' && window.self !== window.top;
+  const embedFallback = (
+    <p className='italic text-sm'>
+      { t(isEditing ? 'embedRenderErrorEditing' : 'embedRenderError') }
+    </p>
+  );
+
   return (
     <RuntimeConfig
       path='/config.json'
@@ -48,7 +58,7 @@ const PostContent = (props: PostContentProps) => {
             >
               <PostEmbedErrorBoundary
                 resetKeys={[data?.post?.body]}
-                fallback={<p className='italic text-sm'>{t('embedRenderError')}</p>}
+                fallback={embedFallback}
               >
                 <TinaMarkdown
                   components={{

--- a/src/components/PostEmbedErrorBoundary.tsx
+++ b/src/components/PostEmbedErrorBoundary.tsx
@@ -6,9 +6,9 @@ interface Props {
   /**
    * When any value in this array changes (compared positionally with
    * `Object.is`), a boundary that is currently showing its fallback resets and
-   * re-renders its children. Pass something derived from the rendered content
-   * (e.g. the post body) so the preview recovers on the next edit instead of
-   * staying stuck on the fallback until a full reload.
+   * re-renders its children, and the auto-retry budget is replenished. Pass
+   * something derived from the rendered content (e.g. the post body) so the
+   * preview recovers on the next edit even if auto-retry was exhausted.
    */
   resetKeys?: ReadonlyArray<unknown>;
   onError?: (error: Error, info: ErrorInfo) => void;
@@ -17,7 +17,21 @@ interface Props {
 interface State {
   hasError: boolean;
   resetKeys: ReadonlyArray<unknown>;
+  retryCount: number;
 }
+
+/**
+ * Most embed crashes are one-shot teardown throws from children that are already
+ * unmounted (see class comment), so an automatic retry restores the preview.
+ * Removing one map can throw several times in a single synchronous burst (the
+ * removed map plus index-keyed siblings that remount), so the retry is deferred
+ * and de-duplicated — one retry per burst, after the burst settles. The cap
+ * counts bursts, not individual throws, so a genuine render-phase error (one
+ * that throws on every render) can only retry a few times before we leave the
+ * fallback up — rather than letting React escalate repeated failures into a root
+ * unmount, which would tear down the editor and lose unsaved edits.
+ */
+const MAX_AUTO_RETRIES = 3;
 
 /**
  * Returns true when two resetKeys arrays differ in length or in any positional
@@ -42,11 +56,19 @@ export const resetKeysChanged = (
  * are lost. React routes commit-phase errors to the nearest *mounted* ancestor
  * boundary, so this must wrap the whole body (a boundary inside a removed block
  * is itself being deleted and can't catch its own teardown throw).
+ *
+ * On catch it auto-retries once (see `MAX_AUTO_RETRIES`) so the preview heals
+ * itself after a one-shot teardown throw instead of stranding the editor on the
+ * fallback until the next keystroke.
  */
 class PostEmbedErrorBoundary extends React.Component<Props, State> {
+  // Pending deferred retry; held so a burst of throws schedules only one retry
+  // and so the timer can be cleared if we unmount first.
+  private retryTimer: ReturnType<typeof setTimeout> | undefined;
+
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, resetKeys: props.resetKeys ?? [] };
+    this.state = { hasError: false, resetKeys: props.resetKeys ?? [], retryCount: 0 };
   }
 
   static getDerivedStateFromError(): Partial<State> {
@@ -57,11 +79,13 @@ class PostEmbedErrorBoundary extends React.Component<Props, State> {
     const changed = resetKeysChanged(props.resetKeys, state.resetKeys);
 
     if (state.hasError && changed) {
-      return { hasError: false, resetKeys: props.resetKeys ?? [] };
+      return { hasError: false, resetKeys: props.resetKeys ?? [], retryCount: 0 };
     }
 
     if (changed) {
-      return { resetKeys: props.resetKeys ?? [] };
+      // New content: clear the error state already handled above; replenish the
+      // retry budget so a later, unrelated crash gets its own attempt.
+      return { resetKeys: props.resetKeys ?? [], retryCount: 0 };
     }
 
     return null;
@@ -71,6 +95,31 @@ class PostEmbedErrorBoundary extends React.Component<Props, State> {
     // Keep the throw visible; the boundary only suppresses the crash, not the signal.
     console.error('Post embed crashed; contained to keep the editor alive.', error, info);
     this.props.onError?.(error, info);
+    this.scheduleRetry();
+  }
+
+  componentWillUnmount() {
+    if (this.retryTimer !== undefined) {
+      clearTimeout(this.retryTimer);
+    }
+  }
+
+  /**
+   * Schedules a single deferred retry per burst. Deferring to a macrotask lets a
+   * whole cascade of teardown throws settle first, so the retry re-renders once
+   * against the already-corrected content and succeeds. Re-rendering only reads
+   * the current (already-edited) content — it never touches form state — so
+   * edits are never lost. The cap bounds a genuine render-phase loop.
+   */
+  private scheduleRetry() {
+    if (this.retryTimer !== undefined || this.state.retryCount >= MAX_AUTO_RETRIES) {
+      return;
+    }
+
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = undefined;
+      this.setState((state) => ({ hasError: false, retryCount: state.retryCount + 1 }));
+    }, 0);
   }
 
   render() {

--- a/src/components/PostEmbedErrorBoundary.tsx
+++ b/src/components/PostEmbedErrorBoundary.tsx
@@ -1,0 +1,85 @@
+import React, { type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  /**
+   * When any value in this array changes (compared positionally with
+   * `Object.is`), a boundary that is currently showing its fallback resets and
+   * re-renders its children. Pass something derived from the rendered content
+   * (e.g. the post body) so the preview recovers on the next edit instead of
+   * staying stuck on the fallback until a full reload.
+   */
+  resetKeys?: ReadonlyArray<unknown>;
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface State {
+  hasError: boolean;
+  resetKeys: ReadonlyArray<unknown>;
+}
+
+/**
+ * Returns true when two resetKeys arrays differ in length or in any positional
+ * value (compared with `Object.is`).
+ */
+export const resetKeysChanged = (
+  a: ReadonlyArray<unknown> = [],
+  b: ReadonlyArray<unknown> = []
+): boolean => a.length !== b.length || a.some((value, index) => !Object.is(value, b[index]));
+
+/**
+ * Contains render- and unmount-time crashes from post body embeds so a single
+ * failing visualization can't take down the whole TinaCMS visual editor.
+ *
+ * The post body renders every embed (`<map>`, `<place>`, `<timeline>`, ...)
+ * through `TinaMarkdown` inside a `client:only` island with no error handling.
+ * Removing a map embed unmounts a MapLibre map whose layer/image children clean
+ * up against an already-torn-down style (`map.removeImage` /
+ * `map.getStyle().layers` read on an undefined style), throwing during React's
+ * passive-effect unmount. With no boundary, React unmounts the entire root —
+ * the editor preview and its visual-editing bridge go blank and unsaved edits
+ * are lost. React routes commit-phase errors to the nearest *mounted* ancestor
+ * boundary, so this must wrap the whole body (a boundary inside a removed block
+ * is itself being deleted and can't catch its own teardown throw).
+ */
+class PostEmbedErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, resetKeys: props.resetKeys ?? [] };
+  }
+
+  static getDerivedStateFromError(): Partial<State> {
+    return { hasError: true };
+  }
+
+  static getDerivedStateFromProps(props: Props, state: State): Partial<State> | null {
+    const changed = resetKeysChanged(props.resetKeys, state.resetKeys);
+
+    if (state.hasError && changed) {
+      return { hasError: false, resetKeys: props.resetKeys ?? [] };
+    }
+
+    if (changed) {
+      return { resetKeys: props.resetKeys ?? [] };
+    }
+
+    return null;
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Keep the throw visible; the boundary only suppresses the crash, not the signal.
+    console.error('Post embed crashed; contained to keep the editor alive.', error, info);
+    this.props.onError?.(error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? null;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default PostEmbedErrorBoundary;

--- a/src/i18n/i18n.json
+++ b/src/i18n/i18n.json
@@ -463,6 +463,10 @@
     "tinaLabel": "Post embed render error message",
     "defaultValue": "This content could not be displayed."
   },
+  "embedRenderErrorEditing": {
+    "tinaLabel": "Post embed render error message (visual editor)",
+    "defaultValue": "This content could not be previewed. Your edits are safe — the preview will refresh as you keep editing."
+  },
   "contactForm.name": {
     "tinaLabel": "Contact Form > Name",
     "defaultValue": "Name"

--- a/src/i18n/i18n.json
+++ b/src/i18n/i18n.json
@@ -459,6 +459,10 @@
     "tinaLabel": "All Posts",
     "defaultValue": "All Posts"
   },
+  "embedRenderError": {
+    "tinaLabel": "Post embed render error message",
+    "defaultValue": "This content could not be displayed."
+  },
   "contactForm.name": {
     "tinaLabel": "Contact Form > Name",
     "defaultValue": "Name"

--- a/test/postEmbedErrorBoundary.test.ts
+++ b/test/postEmbedErrorBoundary.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import PostEmbedErrorBoundary, { resetKeysChanged } from '../src/components/PostEmbedErrorBoundary';
+
+describe('resetKeysChanged', () => {
+  it('returns false for equal key arrays', () => {
+    const body = { children: [] };
+    expect(resetKeysChanged([body], [body])).toBe(false);
+    expect(resetKeysChanged([], [])).toBe(false);
+    expect(resetKeysChanged(['a', 1], ['a', 1])).toBe(false);
+  });
+
+  it('returns true when a positional value differs', () => {
+    expect(resetKeysChanged([{ children: ['a'] }], [{ children: ['b'] }])).toBe(true);
+    expect(resetKeysChanged(['a'], ['b'])).toBe(true);
+  });
+
+  it('returns true when the arrays differ in length', () => {
+    expect(resetKeysChanged(['a'], ['a', 'b'])).toBe(true);
+    expect(resetKeysChanged([], ['a'])).toBe(true);
+  });
+
+  it('treats missing arrays as empty', () => {
+    expect(resetKeysChanged(undefined, undefined)).toBe(false);
+    expect(resetKeysChanged(undefined, ['a'])).toBe(true);
+    expect(resetKeysChanged(['a'], undefined)).toBe(true);
+  });
+
+  it('compares with Object.is (same reference is unchanged)', () => {
+    const ref = {};
+    expect(resetKeysChanged([ref], [ref])).toBe(false);
+    expect(resetKeysChanged([{}], [{}])).toBe(true);
+  });
+});
+
+describe('PostEmbedErrorBoundary.getDerivedStateFromError', () => {
+  it('flips into the error state so the fallback renders instead of the crash', () => {
+    expect(PostEmbedErrorBoundary.getDerivedStateFromError()).toEqual({ hasError: true });
+  });
+});
+
+describe('PostEmbedErrorBoundary.getDerivedStateFromProps', () => {
+  const propsFor = (resetKeys: ReadonlyArray<unknown>) => ({ children: null, resetKeys });
+
+  it('clears the error and adopts new keys when resetKeys change after a crash', () => {
+    const next = ['v2'];
+    const result = PostEmbedErrorBoundary.getDerivedStateFromProps(
+      propsFor(next),
+      { hasError: true, resetKeys: ['v1'] }
+    );
+    expect(result).toEqual({ hasError: false, resetKeys: next });
+  });
+
+  it('stays in the error state while resetKeys are unchanged', () => {
+    const keys = ['v1'];
+    const result = PostEmbedErrorBoundary.getDerivedStateFromProps(
+      propsFor(keys),
+      { hasError: true, resetKeys: keys }
+    );
+    expect(result).toBeNull();
+  });
+
+  it('tracks new keys without resetting when there is no error', () => {
+    const next = ['v2'];
+    const result = PostEmbedErrorBoundary.getDerivedStateFromProps(
+      propsFor(next),
+      { hasError: false, resetKeys: ['v1'] }
+    );
+    expect(result).toEqual({ resetKeys: next });
+  });
+
+  it('is a no-op when there is no error and keys are unchanged', () => {
+    const keys = ['v1'];
+    const result = PostEmbedErrorBoundary.getDerivedStateFromProps(
+      propsFor(keys),
+      { hasError: false, resetKeys: keys }
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/test/postEmbedErrorBoundary.test.ts
+++ b/test/postEmbedErrorBoundary.test.ts
@@ -41,38 +41,38 @@ describe('PostEmbedErrorBoundary.getDerivedStateFromError', () => {
 describe('PostEmbedErrorBoundary.getDerivedStateFromProps', () => {
   const propsFor = (resetKeys: ReadonlyArray<unknown>) => ({ children: null, resetKeys });
 
-  it('clears the error and adopts new keys when resetKeys change after a crash', () => {
+  it('clears the error and replenishes the retry budget when resetKeys change after a crash', () => {
     const next = ['v2'];
     const result = PostEmbedErrorBoundary.getDerivedStateFromProps(
       propsFor(next),
-      { hasError: true, resetKeys: ['v1'] }
+      { hasError: true, resetKeys: ['v1'], retryCount: 1 }
     );
-    expect(result).toEqual({ hasError: false, resetKeys: next });
+    expect(result).toEqual({ hasError: false, resetKeys: next, retryCount: 0 });
   });
 
-  it('stays in the error state while resetKeys are unchanged', () => {
+  it('stays in the error state while resetKeys are unchanged (no extra retries handed out)', () => {
     const keys = ['v1'];
     const result = PostEmbedErrorBoundary.getDerivedStateFromProps(
       propsFor(keys),
-      { hasError: true, resetKeys: keys }
+      { hasError: true, resetKeys: keys, retryCount: 1 }
     );
     expect(result).toBeNull();
   });
 
-  it('tracks new keys without resetting when there is no error', () => {
+  it('tracks new keys and replenishes the retry budget when there is no error', () => {
     const next = ['v2'];
     const result = PostEmbedErrorBoundary.getDerivedStateFromProps(
       propsFor(next),
-      { hasError: false, resetKeys: ['v1'] }
+      { hasError: false, resetKeys: ['v1'], retryCount: 1 }
     );
-    expect(result).toEqual({ resetKeys: next });
+    expect(result).toEqual({ resetKeys: next, retryCount: 0 });
   });
 
   it('is a no-op when there is no error and keys are unchanged', () => {
     const keys = ['v1'];
     const result = PostEmbedErrorBoundary.getDerivedStateFromProps(
       propsFor(keys),
-      { hasError: false, resetKeys: keys }
+      { hasError: false, resetKeys: keys, retryCount: 0 }
     );
     expect(result).toBeNull();
   });


### PR DESCRIPTION
## Summary

Closes #647. Removing a `<map>` embed from a post in the TinaCMS visual editor crashed the whole editor — both the preview and the form went blank, a reload was required, and unsaved edits were lost. This wraps the post body in an error boundary so a single embed's crash is contained, the editor stays usable, and the preview recovers on its own.

## Root cause

The post body renders every embed (`<map>`, `<place>`, `<timeline>`, …) through `TinaMarkdown` in `PostContent.tsx`, mounted as a `client:only` island with no error handling. Removing a map unmounts a MapLibre map whose layer/image children clean up against an already-torn-down style:

```
TypeError: Cannot read properties of undefined (reading 'removeImage')
    at Map.removeImage (maplibre)
    at safelyCallDestroy → commitHookEffectListUnmount
    at commitPassiveUnmountInsideDeletedTreeOnFiber → … → flushPassiveEffects
```

It's a throw in a `useEffect` cleanup during unmount, in `@peripleo/maplibre`. With no error boundary, React unmounts the entire root, which also tears down the visual-editing bridge and clears the form. Our visual editor is probably an outlier in terms peripleo integrations, but I'll discuss with @aboutgeo whether a fix could make its way upstream.

This is **pre-existing**, not introduced by #646: it reproduces both with and without that PR's per-instance `MapProvider`. (Without it, the same teardown throws `map.getStyle().layers` instead — the cross-contamination crash the `MapProvider` change was added to fix.)

## The fix

`PostEmbedErrorBoundary` wraps `<TinaMarkdown>`. React routes commit-phase errors (including effect-cleanup throws) to the nearest *mounted* ancestor boundary, so the editor island stays mounted — no blank page, no reload, **edits are preserved**. The boundary wraps the whole body deliberately: a per-embed boundary inside the removed block is itself being deleted and can't catch its own teardown throw — only an ancestor can.

It also recovers on its own:

- **Auto-retry.** On catch, the boundary schedules a single deferred, de-duplicated retry. Removing a map throws several times in one synchronous burst (the removed map plus index-keyed siblings that remount), so the retry waits for the burst to settle and runs once, re-rendering the corrected content. The retry budget counts *bursts* and is capped, so a genuine render-phase error (throws every render) stops on the fallback after a few attempts instead of looping into a root unmount. The retry only re-renders from current content and never touches form state, so edits are never lost.
- **resetKeys.** Keyed on the post body, so the budget replenishes and the boundary resets on each content edit even if auto-retry was exhausted.
- **Context-aware fallback copy.** The fallback is, in practice, only hit inside the visual editor, so it shows a reassuring "your edits are safe" message there and a neutral one on a normally-loaded published page.

## Known behavior / follow-up

The boundary *contains and recovers from* the throw; it doesn't prevent it. Eliminating the throw at the source needs an upstream guard on the `@peripleo/maplibre` layer/image cleanup (e.g. `if (map?.style)` before `removeImage` / `getStyle().layers`) — worth filing separately; out of scope here to keep this tightly scoped.

## Verification

- Reproduced the crash and verified the fix in the live visual editor (Playwright) on a post with multiple map embeds: before — both panels blank, reload needed; after — editor stays mounted, form intact with the removal applied, and the preview auto-recovers (the fallback flashes briefly during the teardown burst, then the maps re-render).
- `npm run vitest` green (122 passed, 3 skipped), including `test/postEmbedErrorBoundary.test.ts` covering the boundary's error/reset logic.

## Test plan

- [ ] Open a post with a `<map>` embed in the visual editor; remove the map. Editor stays mounted; no reload; the preview recovers; the change can be saved.
- [ ] Remove the first of several embeds (forces trailing remounts); editor survives and recovers.
- [ ] Live published post with maps renders normally; fallback does not appear in the happy path.