### PR TITLE
Guard null place_geometry.properties in place map panel

### DIFF
--- a/src/apps/search/map/panels/Place.tsx
+++ b/src/apps/search/map/panels/Place.tsx
@@ -36,7 +36,7 @@ const Place = (props: Props) => {
     if (place?.place_geometry) {
       let feature = CoreDataUtils.toFeature(place);
 
-      const certaintyRadius = feature.properties.originalProperties.certainty_radius;
+      const certaintyRadius = feature.properties?.originalProperties?.certainty_radius;
       if (certaintyRadius) {
         feature = MapUtils.toCertaintyCircle(feature, certaintyRadius);
       }


### PR DESCRIPTION
Add optional chaining when reading `certainty_radius` in the place search-map panel, so a place whose `place_geometry.properties` is null no longer crashes the map.

## Why

Clicking a place result called `feature.properties.originalProperties.certainty_radius` directly. The library's `toFeature` sets `originalProperties` from `place_geometry.properties`; when that is null, the unguarded access throws `Uncaught TypeError: Cannot read properties of null (reading 'certainty_radius')` and the search-map island crashes.

Most data has `place_geometry.properties: {}` (an empty object), so the bug stayed latent. Data migrated from Nodegoat (e.g. the RelNet project) writes `null` instead, which triggers it. Every other `certainty_radius` read in the codebase — `BasePanel`, `PlaceMap`, and the library's own `getFeatures` — already optional-chains it; this brings `Place.tsx` in line.

## Testing

Reproduced on a staging site (clicking any place crashed the map), applied this fix on a v1.9.0-based branch, redeployed, and confirmed the place panel and map render with no console error.