### PR TITLE
Update README for v1.9.0: Node 24, Clerk SSO, remove user-seeding step

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A map-centric website backed by a Core Data project and Typesense index.
 ## Getting Started
 
 #### Requirements
-- Node 20.x
+- Node 24.x
 - Netlify CLI
 - Core Data Project
 - Typesense Index
@@ -78,10 +78,6 @@ content
 ├── users
 │   ├── index.json
 ```
-
-###### Users
-
-Copy the `/data/users.json` file into your content repository to `/content/users/index.json`. This will seed TinaCMS with the initial set of user accounts, which can be used to setup accounts for other users, then removed. Skip this step if you are using an SSO provider or institutional IdP to manage users instead.
 
 ###### Branding
 
@@ -232,9 +228,17 @@ After the user is created, use the "Security Credentials" tab to create an acces
 
 Create a new site on Netlify deployed from the `core-data-places` repository. Set all of the environment variables in .env.example as appropriate. Currently, Core Data Places can only be hosted on Netlify in "server" mode, as the TinaCMS functions are dependent on Netlify functions.
 
-#### Single Sign On
+#### Single Sign On (Clerk)
 
-See [Keycloak](docs/sso/keycloak-setup.md) documentation for single sign on.
+As of v1.9.0, deployed sites authenticate the TinaCMS admin via **Clerk SSO**. The previous Keycloak and username/password (`tinacms-authjs`) paths have been removed — a non-local build now fails fast if the Clerk variables are missing. Set three environment variables on the Netlify site:
+
+- `TINA_PUBLIC_CLERK_PUBLIC_KEY` — Clerk publishable key (`pk_live_…`)
+- `TINA_PUBLIC_CLERK_ORG_ID` — the Clerk organization whose members may edit this site
+- `CLERK_SECRET` — Clerk secret key (`sk_live_…`); used by the `tina` Netlify function for token verification and RBAC (mark it secret)
+
+Editor access is membership in the org named by `TINA_PUBLIC_CLERK_ORG_ID`: role `org:admin` grants full access, `org:member` is restricted (per-collection rules are enforced in `netlify/functions/tina.ts`). Because Clerk's frontend API rejects bare `*.netlify.app` origins, the admin must be served from a domain the Clerk app trusts (typically a `*.performant.studio` custom domain).
+
+For local development, set `TINA_PUBLIC_IS_LOCAL=true` to use the local auth provider instead — no Clerk required.
 
 #### Static Build
 


### PR DESCRIPTION
The README still documented setup steps that were removed in v1.9.0, so anyone following it to set up a site gets wrong instructions.

## Changes
- **Node 20.x → 24.x**, matching `.node-version`.
- **Single Sign-On section: Keycloak → Clerk.** Clerk is the only auth option for deployed sites as of v1.9.0 — Keycloak and the username/password path were removed, and a deployed build now stops with an error if the Clerk variables are missing. Documents the three `TINA_PUBLIC_CLERK_*` / `CLERK_SECRET` variables, the organization-membership access model, and the custom-domain requirement (Clerk rejects bare `*.netlify.app` origins).
- **Removed the `content/users/index.json` seeding step**, which TinaCMS no longer uses as of v1.9.0.

Scoped to the inaccurate instructions only; the broader Core Data Places → FairData Sites rename is a separate change.