### PR TITLE
Add Dependabot config to batch security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot configuration.
+#
+# This repo previously ran with no config file, so it took GitHub's default
+# behavior: one PR per security advisory, unbatched. That produced a large
+# volume of overlapping PRs (e.g. several netlify-cli lockfile bumps that each
+# carried one extra advisory and conflicted with each other).
+#
+# This config keeps the security safety net but consolidates it:
+#   - security updates are grouped into a single weekly PR per ecosystem
+#   - version-bump PRs are turned off (open-pull-requests-limit: 0) so we are
+#     not chasing non-security upgrades on Dependabot's schedule
+#
+# To also receive batched version-bump PRs later, raise the limit and add a
+# second group with `applies-to: version-updates`.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml`. The repo had no Dependabot config, so it ran on GitHub's defaults: one PR per security advisory, unbatched.

## Why

That default produced a high volume of overlapping PRs — for example several `netlify-cli` version bumps that each carried one extra advisory and conflicted with one another.

## Change

- This PR groups security updates into a single weekly PR per ecosystem.
- Turns off version-bump PRs; security coverage continues.

To batch version bumps later, raise the limit and add a `version-updates` group.

## Note

Once this merges, Dependabot consolidates the existing scattered security PRs into one grouped PR on its next run — no manual closing needed.