### PR TITLE
Use MAPTILER_KEY placeholder in example config; document per-site key setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Copy the `.env.example` file to `.env` and enter required variables. For a local
 
 Add a `/public/config.dev.json` file, which will be ignored by Git, to copy local config settings when starting the application. Use the `config.json` table below to configure your project.
 
+#### MapTiler API key
+
+Map layers reference a MapTiler style URL (`layers[].url`) that embeds an API key. `config.json` is served publicly, so treat the key as visible to every visitor:
+
+1. Generate a **new key for each site** in [MapTiler Cloud](https://cloud.maptiler.com/account/keys/) — don't reuse a key across sites.
+2. Restrict the key to the site's domains under **Allowed HTTP origins** (include `localhost` for local development). An unrestricted key can be copied from the public config and used by anyone, consuming your quota.
+3. Replace the `MAPTILER_KEY` placeholder in your config with the new key.
+
 To start, run:
 ```
 npm install && netlify dev

--- a/public/config.example.json
+++ b/public/config.example.json
@@ -20,7 +20,7 @@
   "layers": [{
     "name": "Maptiler DataViz Style",
     "layer_type": "vector",
-    "url": "https://api.maptiler.com/maps/dataviz/style.json?key=WLMbLZP1AwK3zUFTeheB"
+    "url": "https://api.maptiler.com/maps/dataviz/style.json?key=MAPTILER_KEY"
   }],
   "search": [{
     "name": "places",


### PR DESCRIPTION
Removes a real MapTiler API key from `public/config.example.json` — sites scaffolded from the example were inheriting a shared, unrestricted key. Replaces it with a `MAPTILER_KEY` placeholder (matching the other placeholders) and adds a README step on generating a per-site key and restricting it to the site's domains.

Prompted by a report from Pace University's security team about the shared key being visible on their GBoF sites.

Closes #21.