### PR TITLE
Fix inverted condition in getDetailPagePaths

### DIFF
--- a/src/utils/detailPages.ts
+++ b/src/utils/detailPages.ts
@@ -7,7 +7,7 @@ import { hasDetailPage } from '@utils/detailPagePaths';
 export const getDetailPagePaths = async (model: Models) => {
   let routes = [];
 
-  if (hasDetailPage(model)) {
+  if (!hasDetailPage(model)) {
     return routes;
   }
 


### PR DESCRIPTION
`getDetailPagePaths` returned an empty route list for models that **have** configured detail pages, so a static build (`STATIC_BUILD=true`) prerendered detail pages for exactly the wrong set of models. SSR is unaffected because `getStaticPaths` is never called there.

One-line fix: negate the `hasDetailPage` guard. Verified on a static build of an internal site — the configured models (people, places, works) now get detail routes and the unconfigured ones don't.

Fixes #729