### PR TITLE
Add `pathname` prop to header in Tina preview

### DIFF
--- a/src/apps/pages/Page.astro
+++ b/src/apps/pages/Page.astro
@@ -24,6 +24,7 @@ setCacheControl(Astro.response.headers);
           fullscreen
           image={branding?.header?.logo}
           imageAlt={branding.title}
+          pathname={Astro.url.pathname}
           title={branding?.header?.hide_title ? undefined : branding.title}
           transparent={page.transparent}
           isTinaPreview


### PR DESCRIPTION
### In this PR
As of PR #747 , the `Header` component accepts a `pathname` prop from the `Layout` component. This PR adds that prop value to the instance of the `Header` component used inside visual editor previews. (The reason for rendering the header differently in the preview is so that Tina will live-update it if you change the transparency setting; it will only update things within the `Page` component, which in the normal layout the header is not.)