### PR TITLE
Adding default locale backup in page component

### DIFF
--- a/src/apps/pages/Page.astro
+++ b/src/apps/pages/Page.astro
@@ -7,13 +7,17 @@ import clsx from 'clsx';
 import branding from '@branding';
 import { getNavbar } from '@services/navbar';
 import { getPages } from '@utils/nav';
+import { getDefaultLocale } from '@utils/i18n';
 
 const { page, isTinaPreview, t } = Astro.props;
 
 setCacheControl(Astro.response.headers);
 
-const navbar = await getNavbar(Astro.currentLocale);
-const pages = await getPages(Astro.currentLocale);
+const defaultLocale = getDefaultLocale();
+
+// Default is necessary for tina visual editor islands
+const navbar = await getNavbar(Astro.currentLocale || defaultLocale);
+const pages = await getPages(Astro.currentLocale || defaultLocale);
 
 ---
 <div data-tina-field={tinaField(page)}>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,0 +1,5 @@
+import config from '@config';
+
+export const getDefaultLocale = () => {
+  return config.i18n?.default_locale;
+}


### PR DESCRIPTION
### In this PR
Fixes a bug in the visual editor where the `Page` component attempts to call `getNavbar` with an undefined locale when it refreshes the Tina island content.