### PR TITLE
tina/database.ts: honor TINA_DATALAYER_PORT for the local datalayer

### DIFF
--- a/tina/database.ts
+++ b/tina/database.ts
@@ -13,7 +13,15 @@ const branch =
   'main';
 
 export default isLocal
-  ? createLocalDatabase()
+  // TINA_DATALAYER_PORT moves the local datalayer off its default port
+  // (9000). Tina's --datalayer-port flag moves only the server; this client
+  // must follow, or local dev hangs at "Indexing local files". Set by
+  // pstudio workspaces so two sites can run side by side.
+  ? createLocalDatabase(
+    process.env.TINA_DATALAYER_PORT
+      ? { port: Number(process.env.TINA_DATALAYER_PORT) }
+      : undefined
+  )
   : createDatabase({
     gitProvider: new GitHubProvider({
       branch,


### PR DESCRIPTION
Tina's `--datalayer-port` flag moves only the datalayer server. On self-hosted sites like ours, the client comes from `tina/database.ts`, which always dialed the default port 9000 — so moving the port made local dev hang forever at "Indexing local files" while the server listened, unreached, on the new port.

The client now follows `TINA_DATALAYER_PORT` when it is set, and behaves exactly as before when it is not. pstudio's new per-site workspaces (pstudio#81) set the variable so two sites can run local dev side by side without contending for port 9000.

Verified both ways in a juel-staging workspace: without this change and a moved port, indexing hangs; with it, the datalayer serves on the moved port, 9000 stays free, and the site works.