### PR TITLE
Dev toolbar app: site identity, workspace awareness, and a control surface

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ import { loadEnv } from 'vite';
 import config from './public/config.json';
 import tina from '@tinacms/astro/integration';
 import { tinaAdminDevRedirect } from '@tinacms/astro/vite';
+import fdsToolbar from './integrations/fds-toolbar/index.mjs';
 
 const { locales, default_locale: defaultLocale } = config.i18n;
 const { STATIC_BUILD } = loadEnv(process.env.STATIC_BUILD, process.cwd(), '');
@@ -24,7 +25,7 @@ export default defineConfig({
   },
   output: STATIC_BUILD === 'true' ? 'static' : 'server',
   adapter: netlify(),
-  integrations: [mdx(), sitemap(), react(), tina()],
+  integrations: [mdx(), sitemap(), react(), tina(), fdsToolbar()],
   vite: {
     optimizeDeps: {
       esbuildOptions: {

--- a/integrations/fds-toolbar/PLAN.md
+++ b/integrations/fds-toolbar/PLAN.md
@@ -1,0 +1,61 @@
+# FDS dev toolbar — feature plan
+
+Status: sketch on `feat/fds-dev-toolbar` (2026-07-16), not yet PR'd. v1–v3
+built and verified live: identity panel (site/env/ref/content repo/FAIR
+endpoints), production-tier warning (red badge + persistent icon dot),
+live state push (watches `.fds-dev.json` and `.git/HEAD` via Vite's
+watcher), working Stop button (delegates to `dhtools fds dev stop`), and
+stubbed action buttons.
+
+The toolbar exists only under `astro dev` — never in builds, static or SSR.
+Its server half runs on the developer's machine with their credentials,
+which is what lets local buttons act on remote (staging) targets.
+
+## To build, in rough order
+
+1. **Rebuild content** (local) — re-run `scripts/build.mjs` with the
+   session's env from the toolbar: refetch config.json, content repo, and
+   search.json without restarting the dev server. Machinery proven (the
+   fds dev pre-build does exactly this); needs a busy state in the UI and
+   a push when done.
+
+2. **Trigger rebuild** (staging) — fire the staging deploy's rebuild from
+   the toolbar. Plumbing exists: the deployed `rebuild` edge function /
+   Netlify build hook; the toolbar's server side has the Netlify CLI.
+
+3. **Reindex search** (staging) — run the Typesense reindex rake task
+   against the staging backend (today: Heroku rake, per the local-dev
+   workflow docs).
+
+4. **Clear cache** (local) — clear the content cache used when
+   USE_CONTENT_CACHE=true and nudge a reload.
+
+5. **Static-preview section** — dev-only middleware serving the latest
+   `fds static` bake (`dist/`) at `/__static-preview/`, with toolbar links
+   to the baked FAIR artifacts: Linked Art JSON, baked search index,
+   pmtiles map preview, IIIF snapshots. Shown only when a bake exists.
+   This is the "static dev mode" idea: the dev server is the thin layer
+   for inspecting static output; deployed static sites never get a toolbar.
+
+6. **More endpoints as they get homes** — FairCopy Server, FairImage, the
+   Performant Studio dashboard (fairdata.performant.studio). Not linked
+   yet because no site env/config carries their URLs; each is a two-line
+   addition to `collectState` once a source of truth exists.
+
+## Separate track (not this integration)
+
+An on-staging admin widget (Clerk-gated, baked into the framework) so
+content editors can trigger rebuilds from the deployed site without a
+developer's laptop. The deployed `rebuild` edge function is the embryo.
+Sequence after the dev cockpit shows which actions get used.
+
+## Design notes for the PR conversation
+
+- `.fds-dev.json` is now read by two codebases (dhtools writes, this
+  integration reads) — mark the shape as a small contract in dhtools'
+  `daemon.ts` when this merges.
+- All panel values are escaped before `innerHTML`; data sources are the
+  developer's own filesystem and env, dev-only.
+- Stop button delegates to `dhtools fds dev stop` (spawned detached) so
+  cleanup ownership stays in one place; the button renders only for
+  dhtools-managed sessions.

--- a/integrations/fds-toolbar/app.mjs
+++ b/integrations/fds-toolbar/app.mjs
@@ -1,0 +1,60 @@
+/**
+ * Client half of the FDS dev toolbar app. Renders the site/env panel from
+ * state the dev server pushes, and keeps a red notification dot on the
+ * toolbar icon for the whole session when the env is production-tier.
+ */
+import { defineToolbarApp } from 'astro/toolbar';
+
+const row = (label, value) => `
+  <div style="display: flex; gap: 12px; padding: 3px 0;">
+    <span style="opacity: 0.6; min-width: 72px;">${label}</span>
+    <span>${value}</span>
+  </div>`;
+
+const esc = (s) => String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+
+function render(win, state) {
+  const site = state.project
+    ? `${esc(state.project)}/${esc(state.env)}`
+    : 'unknown — not started via fds dev';
+  const badge = state.prodTier
+    ? '<astro-dev-toolbar-badge badge-style="red" size="large">PRODUCTION DATA — Tina edits write to prod</astro-dev-toolbar-badge>'
+    : state.env
+      ? '<astro-dev-toolbar-badge badge-style="green">staging-tier</astro-dev-toolbar-badge>'
+      : '';
+  const links = [
+    '<a href="/admin/index.html" target="_blank" style="color: inherit;">Tina admin</a>',
+    state.publicDomain ? `<a href="https://${esc(state.publicDomain)}" target="_blank" style="color: inherit;">${esc(state.publicDomain)}</a>` : null,
+  ].filter(Boolean).join(' &nbsp;·&nbsp; ');
+
+  win.innerHTML = `
+    <header style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px;">
+      <h1 style="font-size: 16px; font-weight: 600; margin: 0;">FairData Site</h1>
+      ${badge}
+    </header>
+    <section style="font-size: 13px; font-family: ui-monospace, monospace;">
+      ${row('Site', site)}
+      ${state.mode ? row('Mode', `${esc(state.mode)}${state.startedAt ? ` (since ${esc(state.startedAt.slice(11, 19))})` : ''}`) : ''}
+      ${state.ref ? row('Ref', esc(state.ref)) : ''}
+      ${state.siteId ? row('Netlify', esc(state.siteId)) : ''}
+      ${row('Links', links)}
+    </section>
+    <footer style="margin-top: 10px;">
+      <astro-dev-toolbar-button size="small" button-style="gray" id="fds-refresh">Refresh</astro-dev-toolbar-button>
+    </footer>`;
+}
+
+export default defineToolbarApp({
+  init(canvas, app, server) {
+    const win = document.createElement('astro-dev-toolbar-window');
+    canvas.appendChild(win);
+
+    server.on('fds-toolbar:state', (state) => {
+      render(win, state);
+      // The dot outlives the window: prod-tier stays flagged on the toolbar
+      // icon even when the panel is closed.
+      app.toggleNotification({ state: state.prodTier === true, level: 'error' });
+      win.querySelector('#fds-refresh')?.addEventListener('click', () => server.send('fds-toolbar:refresh', {}));
+    });
+  },
+});

--- a/integrations/fds-toolbar/app.mjs
+++ b/integrations/fds-toolbar/app.mjs
@@ -1,9 +1,12 @@
 /**
  * Client half of the FDS dev toolbar app. Renders the site/env panel from
- * state the dev server pushes, and keeps a red notification dot on the
- * toolbar icon for the whole session when the env is production-tier.
+ * state the dev server pushes (on init, and again whenever .fds-dev.json or
+ * .git/HEAD change), and keeps a red notification dot on the toolbar icon
+ * for the whole session when the env is production-tier.
  */
 import { defineToolbarApp } from 'astro/toolbar';
+
+const esc = (s) => String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
 
 const row = (label, value) => `
   <div style="display: flex; gap: 12px; padding: 3px 0;">
@@ -11,7 +14,7 @@ const row = (label, value) => `
     <span>${value}</span>
   </div>`;
 
-const esc = (s) => String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+const link = (href, text) => `<a href="${esc(href)}" target="_blank" style="color: inherit;">${esc(text)}</a>`;
 
 function render(win, state) {
   const site = state.project
@@ -22,26 +25,43 @@ function render(win, state) {
     : state.env
       ? '<astro-dev-toolbar-badge badge-style="green">staging-tier</astro-dev-toolbar-badge>'
       : '';
-  const links = [
-    '<a href="/admin/index.html" target="_blank" style="color: inherit;">Tina admin</a>',
-    state.publicDomain ? `<a href="https://${esc(state.publicDomain)}" target="_blank" style="color: inherit;">${esc(state.publicDomain)}</a>` : null,
+
+  // FAIR endpoints, one row each, only when the site knows them.
+  const fairData = state.fairData
+    ? [
+      link(state.fairData, state.fairData.replace(/^https?:\/\//, '')),
+      ...state.fairDataProjects.map((id) => link(`${state.fairData}/projects/${id}`, `project ${id}`)),
+    ].join(' &nbsp;·&nbsp; ')
+    : null;
+  const contentRepo = state.content
+    ? link(`https://github.com/${state.content.repo}${state.content.branch ? `/tree/${state.content.branch}` : ''}`,
+      `${state.content.repo}${state.content.branch ? ` @ ${state.content.branch}` : ''}`)
+    : null;
+  const domains = [
+    state.publicDomain ? link(`https://${state.publicDomain}`, state.publicDomain) : null,
+    state.adminDomain ? link(`https://${state.adminDomain}`, `${state.adminDomain} (admin)`) : null,
   ].filter(Boolean).join(' &nbsp;·&nbsp; ');
 
   win.innerHTML = `
-    <header style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px;">
-      <h1 style="font-size: 16px; font-weight: 600; margin: 0;">FairData Site</h1>
+    <header style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; gap: 12px;">
+      <h1 style="font-size: 16px; font-weight: 600; margin: 0; white-space: nowrap;">FairData Site</h1>
       ${badge}
     </header>
     <section style="font-size: 13px; font-family: ui-monospace, monospace;">
       ${row('Site', site)}
+      ${row('Output', esc(state.output))}
       ${state.mode ? row('Mode', `${esc(state.mode)}${state.startedAt ? ` (since ${esc(state.startedAt.slice(11, 19))})` : ''}`) : ''}
       ${state.ref ? row('Ref', esc(state.ref)) : ''}
+      ${contentRepo ? row('Content', contentRepo) : ''}
+      ${fairData ? row('FairData', fairData) : ''}
+      ${row('Tina', link('/admin/index.html', 'admin'))}
+      ${domains ? row('Domains', domains) : ''}
       ${state.siteId ? row('Netlify', esc(state.siteId)) : ''}
-      ${row('Links', links)}
     </section>
-    <footer style="margin-top: 10px;">
-      <astro-dev-toolbar-button size="small" button-style="gray" id="fds-refresh">Refresh</astro-dev-toolbar-button>
-    </footer>`;
+    ${state.mode ? `
+    <footer style="margin-top: 10px; display: flex; gap: 8px;">
+      <astro-dev-toolbar-button size="small" button-style="red" id="fds-stop">Stop dev server</astro-dev-toolbar-button>
+    </footer>` : ''}`;
 }
 
 export default defineToolbarApp({
@@ -54,7 +74,19 @@ export default defineToolbarApp({
       // The dot outlives the window: prod-tier stays flagged on the toolbar
       // icon even when the panel is closed.
       app.toggleNotification({ state: state.prodTier === true, level: 'error' });
-      win.querySelector('#fds-refresh')?.addEventListener('click', () => server.send('fds-toolbar:refresh', {}));
+
+      // Stop is two-click: arm, then fire. The server side delegates to
+      // `dhtools fds dev stop`, which owns cleanup — this page will go dark.
+      const stop = win.querySelector('#fds-stop');
+      stop?.addEventListener('click', () => {
+        if (stop.dataset.armed === 'true') {
+          server.send('fds-toolbar:stop', {});
+          stop.textContent = 'Stopping…';
+        } else {
+          stop.dataset.armed = 'true';
+          stop.textContent = 'Click again to stop everything';
+        }
+      });
     });
   },
 });

--- a/integrations/fds-toolbar/app.mjs
+++ b/integrations/fds-toolbar/app.mjs
@@ -37,6 +37,15 @@ function render(win, state) {
     ? link(`https://github.com/${state.content.repo}${state.content.branch ? `/tree/${state.content.branch}` : ''}`,
       `${state.content.repo}${state.content.branch ? ` @ ${state.content.branch}` : ''}`)
     : null;
+  // The content clone's working state: an editing session leaves plain
+  // files there, and pushing them is publishing.
+  const clone = state.contentClone
+    ? state.contentClone.dirty === null
+      ? esc(state.contentClone.path)
+      : state.contentClone.dirty === 0
+        ? 'content clone clean'
+        : `<strong>${esc(state.contentClone.dirty)} uncommitted content edit${state.contentClone.dirty === 1 ? '' : 's'}</strong> — pushing publishes`
+    : null;
   const domains = [
     state.publicDomain ? link(`https://${state.publicDomain}`, state.publicDomain) : null,
     state.adminDomain ? link(`https://${state.adminDomain}`, `${state.adminDomain} (admin)`) : null,
@@ -52,7 +61,11 @@ function render(win, state) {
       ${row('Output', esc(state.output))}
       ${state.mode ? row('Mode', `${esc(state.mode)}${state.startedAt ? ` (since ${esc(state.startedAt.slice(11, 19))})` : ''}`) : ''}
       ${state.ref ? row('Ref', esc(state.ref)) : ''}
+      ${state.version ? row('FDS', esc(state.version)) : ''}
+      ${state.workspace?.home ? row('Home', esc(state.workspace.home)) : ''}
       ${contentRepo ? row('Content', contentRepo) : ''}
+      ${clone ? row('Edits', clone) : ''}
+      ${state.datalayer ? row('Datalayer', `:${esc(state.datalayer.port)} ${state.datalayer.isolated ? 'isolated' : 'shared'}`) : ''}
       ${fairData ? row('FairData', fairData) : ''}
       ${row('Tina', link('/admin/index.html', 'admin'))}
       ${domains ? row('Domains', domains) : ''}
@@ -77,7 +90,16 @@ function render(win, state) {
         </div>
       </div>
       <div style="font-size: 11px; opacity: 0.45; margin-top: 8px;">Grayed actions are stubs — hover for what each will do.</div>
-    </section>`;
+    </section>
+    ${state.workspace?.others?.length ? `
+    <section style="margin-top: 12px; border-top: 1px solid rgba(255,255,255,0.15); padding-top: 10px;">
+      <div style="font-size: 11px; opacity: 0.6; margin-bottom: 6px;">OTHER WORKSPACES</div>
+      <div style="font-size: 13px; font-family: ui-monospace, monospace; display: flex; gap: 14px; flex-wrap: wrap;">
+        ${state.workspace.others.map((w) => w.running
+    ? `${link(w.url, w.slug)} <span style="color: #7ee787;">●</span>`
+    : `<span style="opacity: 0.5;">${esc(w.slug)} ○</span>`).join('')}
+      </div>
+    </section>` : ''}`;
 }
 
 export default defineToolbarApp({

--- a/integrations/fds-toolbar/app.mjs
+++ b/integrations/fds-toolbar/app.mjs
@@ -58,10 +58,26 @@ function render(win, state) {
       ${domains ? row('Domains', domains) : ''}
       ${state.siteId ? row('Netlify', esc(state.siteId)) : ''}
     </section>
-    ${state.mode ? `
-    <footer style="margin-top: 10px; display: flex; gap: 8px;">
-      <astro-dev-toolbar-button size="small" button-style="red" id="fds-stop">Stop dev server</astro-dev-toolbar-button>
-    </footer>` : ''}`;
+    <section style="margin-top: 12px; border-top: 1px solid rgba(255,255,255,0.15); padding-top: 10px;">
+      <div style="display: flex; gap: 14px; flex-wrap: wrap;">
+        <div>
+          <div style="font-size: 11px; opacity: 0.6; margin-bottom: 6px;">THIS DEV SERVER</div>
+          <div style="display: flex; gap: 8px;">
+            ${state.mode ? '<astro-dev-toolbar-button size="small" button-style="red" id="fds-stop">Stop</astro-dev-toolbar-button>' : ''}
+            <astro-dev-toolbar-button size="small" button-style="gray" disabled title="Planned: re-run scripts/build.mjs — refetch config, content, and search without a restart">Rebuild content</astro-dev-toolbar-button>
+            <astro-dev-toolbar-button size="small" button-style="gray" disabled title="Planned: clear the content cache (USE_CONTENT_CACHE) and reload">Clear cache</astro-dev-toolbar-button>
+          </div>
+        </div>
+        <div>
+          <div style="font-size: 11px; opacity: 0.6; margin-bottom: 6px;">STAGING (${state.project ? esc(state.project) : 'site'})</div>
+          <div style="display: flex; gap: 8px;">
+            <astro-dev-toolbar-button size="small" button-style="gray" disabled title="Planned: trigger a Netlify rebuild of the staging deploy (the deployed rebuild function already exists)">Trigger rebuild</astro-dev-toolbar-button>
+            <astro-dev-toolbar-button size="small" button-style="gray" disabled title="Planned: re-index the staging Typesense collections">Reindex search</astro-dev-toolbar-button>
+          </div>
+        </div>
+      </div>
+      <div style="font-size: 11px; opacity: 0.45; margin-top: 8px;">Grayed actions are stubs — hover for what each will do.</div>
+    </section>`;
 }
 
 export default defineToolbarApp({

--- a/integrations/fds-toolbar/app.mjs
+++ b/integrations/fds-toolbar/app.mjs
@@ -97,7 +97,7 @@ function render(win, state) {
       <div style="font-size: 13px; font-family: ui-monospace, monospace; display: flex; gap: 14px; flex-wrap: wrap;">
         ${state.workspace.others.map((w) => w.running
     ? `${link(w.url, w.slug)} <span style="color: #7ee787;">●</span>`
-    : `<span style="opacity: 0.5;">${esc(w.slug)} ○</span>`).join('')}
+    : `<span style="color: #6e7681;">${esc(w.slug)} ●</span>`).join('')}
       </div>
     </section>` : ''}`;
 }

--- a/integrations/fds-toolbar/index.mjs
+++ b/integrations/fds-toolbar/index.mjs
@@ -38,11 +38,19 @@ function readWorkspaces() {
   return Array.isArray(ledger?.workspaces) ? ledger.workspaces : [];
 }
 
-const pidAlive = (pid) => {
-  try { process.kill(pid, 0); return true; } catch { return false; }
-};
+/** Does anything answer on this URL? Any HTTP response counts — a stale
+ *  pid in a state file does not (pids get recycled). */
+async function urlAnswers(url) {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 400);
+    await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
+    return true;
+  } catch { return false; }
+}
 
-function collectState(root) {
+async function collectState(root) {
   const fds = readJson(join(root, '.fds-dev.json'));
   const link = readJson(join(root, '.netlify', 'state.json'));
   const config = readJson(join(root, 'public', 'config.json'));
@@ -68,7 +76,7 @@ function collectState(root) {
     publicDomain: PUBLIC_DOMAIN ?? null,
     adminDomain: ADMIN_DOMAIN ?? null,
     version: versionOf(root),
-    workspace: workspaceState(root),
+    workspace: await workspaceState(root),
     contentClone: contentCloneState(root),
     datalayer: {
       port: Number(process.env.TINA_DATALAYER_PORT ?? 9000),
@@ -87,16 +95,16 @@ function versionOf(root) {
 
 /** This folder's workspace record and the other workspaces on the machine,
  *  each with its URL and whether its dev server is running right now. */
-function workspaceState(root) {
+async function workspaceState(root) {
   const workspaces = readWorkspaces();
   const mine = workspaces.find((w) => w.sitePath === root) ?? null;
-  const others = workspaces
+  const others = await Promise.all(workspaces
     .filter((w) => w.sitePath !== root)
-    .map((w) => ({
+    .map(async (w) => ({
       slug: w.slug,
       url: `http://localhost:${w.ports.netlify}`,
-      running: pidAlive(readJson(join(w.sitePath, '.fds-dev.json'))?.pid ?? -1),
-    }));
+      running: await urlAnswers(`http://localhost:${w.ports.netlify}`),
+    })));
   return { home: mine ? dirname(mine.sitePath) : null, slug: mine?.slug ?? null, others };
 }
 
@@ -132,7 +140,7 @@ export default function fdsToolbar() {
       },
       'astro:server:setup': ({ server, toolbar }) => {
         if (!toolbar) return;
-        const send = () => toolbar.send('fds-toolbar:state', collectState(root));
+        const send = async () => toolbar.send('fds-toolbar:state', await collectState(root));
         toolbar.onAppInitialized('fds', send);
         toolbar.on('fds-toolbar:refresh', send);
 

--- a/integrations/fds-toolbar/index.mjs
+++ b/integrations/fds-toolbar/index.mjs
@@ -1,0 +1,68 @@
+/**
+ * FDS dev toolbar app: shows which site and env this dev server is serving,
+ * on every page, all session long — with a persistent warning when the env
+ * is production-tier (local TinaCMS edits write to production data).
+ *
+ * Dev-only: the toolbar exists only under `astro dev`, and both hooks below
+ * no-op everywhere else. Site identity comes from the state `fds dev` writes
+ * (.fds-dev.json), falling back to the Netlify link and injected env vars,
+ * so the panel degrades gracefully when the server was started by hand.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Envs where local TinaCMS edits write to production data (mirrors fds dev). */
+const PROD_TIER = new Set(['production', 'static']);
+
+const readJson = (path) => {
+  try { return JSON.parse(readFileSync(path, 'utf8')); } catch { return null; }
+};
+
+const git = (root, args) => {
+  try { return execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim(); } catch { return null; }
+};
+
+function collectState(root) {
+  const fds = readJson(join(root, '.fds-dev.json'));
+  const link = readJson(join(root, '.netlify', 'state.json'));
+  const branch = git(root, ['rev-parse', '--abbrev-ref', 'HEAD']);
+  const sha = git(root, ['rev-parse', '--short', 'HEAD']);
+  const env = fds?.env ?? null;
+  return {
+    project: fds?.project ?? null,
+    env,
+    prodTier: env !== null && PROD_TIER.has(env),
+    mode: fds?.mode ?? null,
+    startedAt: fds?.startedAt ?? null,
+    siteId: fds?.siteId ?? link?.siteId ?? null,
+    publicDomain: process.env.PUBLIC_DOMAIN ?? null,
+    ref: sha === null ? null : branch === 'HEAD' ? `detached @ ${sha}` : `${branch} @ ${sha}`,
+  };
+}
+
+export default function fdsToolbar() {
+  let root = process.cwd();
+  return {
+    name: 'fds-dev-toolbar',
+    hooks: {
+      'astro:config:setup': ({ addDevToolbarApp, config, command }) => {
+        if (command !== 'dev') return;
+        root = fileURLToPath(config.root);
+        addDevToolbarApp({
+          id: 'fds',
+          name: 'FairData Site',
+          icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 21s-7-5.6-7-11a7 7 0 0 1 14 0c0 5.4-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/></svg>',
+          entrypoint: new URL('./app.mjs', import.meta.url),
+        });
+      },
+      'astro:server:setup': ({ toolbar }) => {
+        if (!toolbar) return;
+        const send = () => toolbar.send('fds-toolbar:state', collectState(root));
+        toolbar.onAppInitialized('fds', send);
+        toolbar.on('fds-toolbar:refresh', send);
+      },
+    },
+  };
+}

--- a/integrations/fds-toolbar/index.mjs
+++ b/integrations/fds-toolbar/index.mjs
@@ -3,12 +3,14 @@
  * on every page, all session long — with a persistent warning when the env
  * is production-tier (local TinaCMS edits write to production data).
  *
- * Dev-only: the toolbar exists only under `astro dev`, and both hooks below
- * no-op everywhere else. Site identity comes from the state `fds dev` writes
- * (.fds-dev.json), falling back to the Netlify link and injected env vars,
- * so the panel degrades gracefully when the server was started by hand.
+ * Dev-only: the toolbar exists only under `astro dev` (never in builds,
+ * static or SSR), and both hooks below no-op everywhere else. Site identity
+ * comes from the state `fds dev` writes (.fds-dev.json), falling back to the
+ * Netlify link and injected env vars; FAIR endpoints come from the site's
+ * own config.json and env, so the panel degrades gracefully when the server
+ * was started by hand.
  */
-import { execFileSync } from 'node:child_process';
+import { spawn, execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -24,12 +26,18 @@ const git = (root, args) => {
   try { return execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim(); } catch { return null; }
 };
 
+const originOf = (url) => {
+  try { return new URL(url).origin; } catch { return null; }
+};
+
 function collectState(root) {
   const fds = readJson(join(root, '.fds-dev.json'));
   const link = readJson(join(root, '.netlify', 'state.json'));
+  const config = readJson(join(root, 'public', 'config.json'));
   const branch = git(root, ['rev-parse', '--abbrev-ref', 'HEAD']);
   const sha = git(root, ['rev-parse', '--short', 'HEAD']);
   const env = fds?.env ?? null;
+  const { GITHUB_OWNER, GITHUB_REPO, GITHUB_BRANCH, ADMIN_DOMAIN, PUBLIC_DOMAIN, STATIC_BUILD, CONFIG_URL } = process.env;
   return {
     project: fds?.project ?? null,
     env,
@@ -37,8 +45,16 @@ function collectState(root) {
     mode: fds?.mode ?? null,
     startedAt: fds?.startedAt ?? null,
     siteId: fds?.siteId ?? link?.siteId ?? null,
-    publicDomain: process.env.PUBLIC_DOMAIN ?? null,
+    output: STATIC_BUILD === 'true' ? 'static' : 'server',
     ref: sha === null ? null : branch === 'HEAD' ? `detached @ ${sha}` : `${branch} @ ${sha}`,
+    content: GITHUB_OWNER && GITHUB_REPO
+      ? { repo: `${GITHUB_OWNER}/${GITHUB_REPO}`, branch: GITHUB_BRANCH ?? null }
+      : null,
+    // FAIR endpoints, as the site itself knows them.
+    fairData: config?.core_data?.url ?? originOf(CONFIG_URL),
+    fairDataProjects: config?.core_data?.project_ids ?? [],
+    publicDomain: PUBLIC_DOMAIN ?? null,
+    adminDomain: ADMIN_DOMAIN ?? null,
   };
 }
 
@@ -57,11 +73,33 @@ export default function fdsToolbar() {
           entrypoint: new URL('./app.mjs', import.meta.url),
         });
       },
-      'astro:server:setup': ({ toolbar }) => {
+      'astro:server:setup': ({ server, toolbar }) => {
         if (!toolbar) return;
         const send = () => toolbar.send('fds-toolbar:state', collectState(root));
         toolbar.onAppInitialized('fds', send);
         toolbar.on('fds-toolbar:refresh', send);
+
+        // Push updates when the session or checkout changes underneath us:
+        // a new fds dev session rewrites .fds-dev.json, a branch switch
+        // rewrites .git/HEAD. Vite's watcher is already running — subscribe
+        // it to both and debounce the burst a git checkout produces.
+        const watched = [join(root, '.fds-dev.json'), join(root, '.git', 'HEAD')];
+        server.watcher.add(watched);
+        let timer = null;
+        server.watcher.on('all', (_event, path) => {
+          if (!watched.includes(path)) return;
+          clearTimeout(timer);
+          timer = setTimeout(send, 100);
+        });
+
+        // Stop button: hand the whole thing to `dhtools fds dev stop`, which
+        // owns the cleanup (.env restore, state file, process group — this
+        // process included). Detached so it survives the group it kills.
+        toolbar.on('fds-toolbar:stop', () => {
+          try {
+            spawn('dhtools', ['fds', 'dev', 'stop'], { cwd: root, detached: true, stdio: 'ignore' }).unref();
+          } catch { /* dhtools not installed — the button is only shown for fds dev sessions */ }
+        });
       },
     },
   };

--- a/integrations/fds-toolbar/index.mjs
+++ b/integrations/fds-toolbar/index.mjs
@@ -12,7 +12,8 @@
  */
 import { spawn, execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /** Envs where local TinaCMS edits write to production data (mirrors fds dev). */
@@ -28,6 +29,17 @@ const git = (root, args) => {
 
 const originOf = (url) => {
   try { return new URL(url).origin; } catch { return null; }
+};
+
+/** The pstudio workspace ledger: which folders serve which site, on which
+ *  ports. Lets the toolbar name this workspace and link to the others. */
+function readWorkspaces() {
+  const ledger = readJson(join(homedir(), '.config', 'pstudio', 'workspaces.json'));
+  return Array.isArray(ledger?.workspaces) ? ledger.workspaces : [];
+}
+
+const pidAlive = (pid) => {
+  try { process.kill(pid, 0); return true; } catch { return false; }
 };
 
 function collectState(root) {
@@ -55,7 +67,52 @@ function collectState(root) {
     fairDataProjects: config?.core_data?.project_ids ?? [],
     publicDomain: PUBLIC_DOMAIN ?? null,
     adminDomain: ADMIN_DOMAIN ?? null,
+    version: versionOf(root),
+    workspace: workspaceState(root),
+    contentClone: contentCloneState(root),
+    datalayer: {
+      port: Number(process.env.TINA_DATALAYER_PORT ?? 9000),
+      isolated: Boolean(process.env.TINA_DATALAYER_PORT),
+    },
   };
+}
+
+/** Nearest version tag plus short commit — what `fds dev status` shows. */
+function versionOf(root) {
+  const sha = git(root, ['rev-parse', '--short=8', 'HEAD']);
+  if (sha === null) return null;
+  const tag = git(root, ['tag', '--sort=-v:refname', '--merged', 'HEAD'])?.split('\n')[0] ?? '';
+  return tag ? `${tag} @ ${sha}` : sha;
+}
+
+/** This folder's workspace record and the other workspaces on the machine,
+ *  each with its URL and whether its dev server is running right now. */
+function workspaceState(root) {
+  const workspaces = readWorkspaces();
+  const mine = workspaces.find((w) => w.sitePath === root) ?? null;
+  const others = workspaces
+    .filter((w) => w.sitePath !== root)
+    .map((w) => ({
+      slug: w.slug,
+      url: `http://localhost:${w.ports.netlify}`,
+      running: pidAlive(readJson(join(w.sitePath, '.fds-dev.json'))?.pid ?? -1),
+    }));
+  return { home: mine ? dirname(mine.sitePath) : null, slug: mine?.slug ?? null, others };
+}
+
+/** The content clone Tina writes to, and how many files an editing session
+ *  has changed there — pushing those is publishing. */
+function contentCloneState(root) {
+  const workspaces = readWorkspaces();
+  const fromLedger = workspaces.find((w) => w.sitePath === root)?.contentPath;
+  const fromEnv = process.env.TINA_LOCAL_CONTENT_PATH
+    ? resolve(join(root, 'tina'), process.env.TINA_LOCAL_CONTENT_PATH)
+    : null;
+  const path = fromLedger ?? fromEnv;
+  if (!path) return null;
+  const status = git(path, ['status', '--porcelain']);
+  if (status === null) return { path, dirty: null };
+  return { path, dirty: status === '' ? 0 : status.split('\n').length };
 }
 
 export default function fdsToolbar() {
@@ -92,13 +149,13 @@ export default function fdsToolbar() {
           timer = setTimeout(send, 100);
         });
 
-        // Stop button: hand the whole thing to `dhtools fds dev stop`, which
+        // Stop button: hand the whole thing to `pstudio fds dev stop`, which
         // owns the cleanup (.env restore, state file, process group — this
         // process included). Detached so it survives the group it kills.
         toolbar.on('fds-toolbar:stop', () => {
           try {
-            spawn('dhtools', ['fds', 'dev', 'stop'], { cwd: root, detached: true, stdio: 'ignore' }).unref();
-          } catch { /* dhtools not installed — the button is only shown for fds dev sessions */ }
+            spawn('pstudio', ['fds', 'dev', 'stop'], { cwd: root, detached: true, stdio: 'ignore' }).unref();
+          } catch { /* pstudio not installed — the button is only shown for fds dev sessions */ }
         });
       },
     },


### PR DESCRIPTION
Adds an Astro dev toolbar app for FairData Sites local development. It exists only under `astro dev` — never in builds, static or SSR.

The panel shows the session's identity on every page: the linked site and environment, with a persistent red badge and toolbar-icon dot when the environment is production-tier (local Tina edits write to production data); the git ref and the FairData Sites framework version in play (nearest version tag plus commit); the content repo and the FairData endpoints as the site knows them; and links to the Tina admin, the public domain, and the Netlify site. State updates live — the server half watches `.fds-dev.json` and `.git/HEAD` and pushes changes to the panel.

It also reads the pstudio workspace ledger: the workspace's home folder, the content clone's uncommitted-edit count (with the reminder that pushing content is publishing), the Tina datalayer port and whether it is isolated per workspace (#767) or shared, and a section listing the machine's other workspaces with a link to each one whose dev server is running.

One action works today: Stop (two-click, delegating to `pstudio fds dev stop`, which owns the cleanup). The other buttons are visible stubs with hover text; `integrations/fds-toolbar/PLAN.md` describes the intended control surface — rebuild content, trigger a staging rebuild, reindex search, clear the cache, and a static-preview section.

The identity panel was verified live against a running site, and the workspace state collector against a machine with six workspaces. The rendered v4 panel additions have not had a visual pass yet — worth one during review.