### PR TITLE
Clear data stores for astro content collections on rebuild

### DIFF
--- a/src/loaders/gallery/index.ts
+++ b/src/loaders/gallery/index.ts
@@ -7,6 +7,9 @@ const loader = {
   load: async (context: LoaderContext): Promise<void> => {
     const { logger, store } = context;
 
+    logger.info('Clearing the data store...');
+    store.clear();
+
     logger.info('Fetching gallery manifests.');
 
     const data = await getManifests();

--- a/src/loaders/i18n/index.ts
+++ b/src/loaders/i18n/index.ts
@@ -9,6 +9,9 @@ const loader = {
   load: async (context: LoaderContext): Promise<void> => {
     const { generateDigest, logger, parseData, store } = context;
 
+    logger.info('Clearing the data store...');
+    store.clear();
+
     logger.info('Fetching data.');
 
     const response = await fetchI18ns();

--- a/src/loaders/navbar/index.ts
+++ b/src/loaders/navbar/index.ts
@@ -8,6 +8,9 @@ const loader = {
   load: async (context: LoaderContext): Promise<void> => {
     const { generateDigest, logger, parseData, store } = context;
 
+    logger.info('Clearing the data store...');
+    store.clear();
+
     logger.info('Fetching data.');
 
     const response = await fetchNavbars();


### PR DESCRIPTION
### In this PR
Resolves #772 by adding `store.clear()` calls to the `i18n`, `navbar`, and `gallery` collection loaders, so that stale data is not persisted on rebuild.

### Notes
For the FairData content loaders, whether or not to clear the store is determined by an environment variable; I considered adding a similar flag here, but I can't really imagine a situation where we want to rebuild the site but keep some old Tina data, so that felt like overcomplicating it. (For the FairData loaders the flag is mainly a convenience for development I believe, since those loaders can take significant time to run from scratch.)
