### PR TITLE
Fixing zoom behavior when `PRELOAD_MAP` is `true`

### DIFF
--- a/src/apps/search/map/MapSearchContext.tsx
+++ b/src/apps/search/map/MapSearchContext.tsx
@@ -75,9 +75,10 @@ export const MapSearchContextProvider = ({ allowSave, children, preload }: Props
   /**
    * Returns a promise that resolves the bounding box for all visible features.
    */
-  const getBoundingBox = useCallback(() => new Promise<LngLatBoundsLike>((resolve) => {
+  const getBoundingBox = useCallback(() => new Promise<LngLatBoundsLike | null>((resolve) => {
     if (!map) {
-      return;
+      resolve(null);
+      return ;
     }
 
     const promises = [];
@@ -101,6 +102,8 @@ export const MapSearchContextProvider = ({ allowSave, children, preload }: Props
           promises.push(Promise.resolve(feature));
         } else if (source) {
           promises.push(source.getData());
+        } else {
+          promises.push(fetch(feature.properties.url).then((res) => (res.json())));
         }
       }
     });
@@ -110,7 +113,7 @@ export const MapSearchContextProvider = ({ allowSave, children, preload }: Props
         // Set the fetched data in the geometry cache
         setGeometryCache((prevCache) => ({
           ...prevCache,
-          ..._.indexBy(data, (d) => d.properties.uuid)
+          ..._.indexBy(_.compact(data), (d) => d.properties.uuid)
         }));
 
         // Calculate the bounding box
@@ -118,6 +121,9 @@ export const MapSearchContextProvider = ({ allowSave, children, preload }: Props
         const bbox = MapUtils.getBoundingBox(featureCollection);
 
         resolve(bbox);
+      })
+      .catch(() => {
+        resolve(null);
       });
   }), [features, geometryCache, map, preload]);
 

--- a/src/apps/search/map/MapSearchContext.tsx
+++ b/src/apps/search/map/MapSearchContext.tsx
@@ -86,7 +86,6 @@ export const MapSearchContextProvider = ({ allowSave, children, preload }: Props
     _.each(features, (feature) => {
       if (feature.properties.visible) {
         const id = feature.properties.uuid;
-        const source = map.getSource(`source-${id}`) as unknown as GeoJSONSource;
 
         const cached = geometryCache[id];
 
@@ -100,8 +99,6 @@ export const MapSearchContextProvider = ({ allowSave, children, preload }: Props
           promises.push(Promise.resolve(cached));
         } else if (!preload) {
           promises.push(Promise.resolve(feature));
-        } else if (source) {
-          promises.push(source.getData());
         } else {
           promises.push(fetch(feature.properties.url).then((res) => (res.json())));
         }

--- a/src/apps/search/map/MapSearchContext.tsx
+++ b/src/apps/search/map/MapSearchContext.tsx
@@ -99,7 +99,7 @@ export const MapSearchContextProvider = ({ allowSave, children, preload }: Props
           promises.push(Promise.resolve(cached));
         } else if (!preload) {
           promises.push(Promise.resolve(feature));
-        } else {
+        } else if (source) {
           promises.push(source.getData());
         }
       }

--- a/src/apps/search/map/MapView.tsx
+++ b/src/apps/search/map/MapView.tsx
@@ -36,27 +36,18 @@ const MapView = () => {
     !isRefinedWithMap() && route === '/' && config.map.zoom_to_place
   ), [route, isRefinedWithMap()]);
 
-  const fitMaptoBounds = useCallback((retries: number = DEFAULT_BOUND_RETRIES) => {
-    getBoundingBox().then((bbox) => {
-      if (bbox) {
-        map.fitBounds(bbox, boundingBoxOptions);
-      } else if (retries > 0) {
-        setTimeout(() => {
-          fitMaptoBounds(retries - 1);
-        }, 500);
-      }
-    })
-  }, [getBoundingBox, map, boundingBoxOptions]);
-
   /**
    * Sets the bounding box on the data set.
    */
   useEffect(() => {
     if (fitBoundingBox && !_.isEmpty(features) && map && !searching) {
-      fitMaptoBounds();
+      getBoundingBox().then((bbox) => {
+        if (bbox) {
+          map.fitBounds(bbox, boundingBoxOptions);
+        }
+      })
     }
   }, [boundingBoxOptions, fitBoundingBox, features, map, searching]);
-
 
   /**
    * Navigate to the `/select` route when feature is selected.

--- a/src/apps/search/map/MapView.tsx
+++ b/src/apps/search/map/MapView.tsx
@@ -6,8 +6,10 @@ import Map from '@components/Map';
 import { useGeoSearch, useSearching } from '@performant-software/core-data';
 import { useLoadedMap, useSelectionValue } from '@peripleo/maplibre';
 import { useCurrentRoute, useNavigate } from '@peripleo/peripleo';
-import { useContext, useEffect, useMemo } from 'react';
+import { useCallback, useContext, useEffect, useMemo } from 'react';
 import _ from 'underscore';
+
+const DEFAULT_BOUND_RETRIES = 3;
 
 const MapView = () => {
   const config = useSearchConfig();
@@ -34,14 +36,27 @@ const MapView = () => {
     !isRefinedWithMap() && route === '/' && config.map.zoom_to_place
   ), [route, isRefinedWithMap()]);
 
+  const fitMaptoBounds = useCallback((retries: number = DEFAULT_BOUND_RETRIES) => {
+    getBoundingBox().then((bbox) => {
+      if (bbox) {
+        map.fitBounds(bbox, boundingBoxOptions);
+      } else if (retries > 0) {
+        setTimeout(() => {
+          fitMaptoBounds(retries - 1);
+        }, 500);
+      }
+    })
+  }, [getBoundingBox, map, boundingBoxOptions]);
+
   /**
    * Sets the bounding box on the data set.
    */
   useEffect(() => {
     if (fitBoundingBox && !_.isEmpty(features) && map && !searching) {
-      getBoundingBox().then((bbox) => map.fitBounds(bbox, boundingBoxOptions));
+      fitMaptoBounds();
     }
   }, [boundingBoxOptions, fitBoundingBox, features, map, searching]);
+
 
   /**
    * Navigate to the `/select` route when feature is selected.

--- a/src/apps/search/map/MapView.tsx
+++ b/src/apps/search/map/MapView.tsx
@@ -6,10 +6,8 @@ import Map from '@components/Map';
 import { useGeoSearch, useSearching } from '@performant-software/core-data';
 import { useLoadedMap, useSelectionValue } from '@peripleo/maplibre';
 import { useCurrentRoute, useNavigate } from '@peripleo/peripleo';
-import { useCallback, useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 import _ from 'underscore';
-
-const DEFAULT_BOUND_RETRIES = 3;
 
 const MapView = () => {
   const config = useSearchConfig();


### PR DESCRIPTION
### In this PR
An attempt to address Issue #736  by a) preventing the `getData()` call on a source that's undefined; and b) if the first call to `getBoundingBox` fails to return any data because the map sources haven't loaded in yet, attempt it twice again at half second intervals and hope that's good enough.

### Notes and questions
Obviously this is not a very satisfying fix, and I have no idea what the right number of retries to go through is before declaring the source data a lost cause, but I don't want to just leave it in a loop of trying to set the bounding box if there's some issue fetching the data. Very much open to other approaches to this. It feels like there ought to be a way to get the `useEffect` hook to do the retrying for us as the map data fills in, but for reasons I don't entirely understand it only seems to trigger once before giving up. The console is littered with this particular error after the map data first loads, and I spent what started to feel like too much time trying to figure out exactly what's causing this: 
<img width="1512" height="1011" alt="image" src="https://github.com/user-attachments/assets/ed9e1fb0-0eea-42a5-88e9-69561e249b67" />
...but it seems to be something deep in the Peripleo package and have something to do with attaching mouseover event listeners? I'm not sure exactly how/whether this error relates to `getBoundingBox` failing to ever re-trigger, but the `setTimeout` thing is basically a way to circumvent the fact that it never naturally manages to try again if the first attempt at getting a bounding box returned no data.