### PR TITLE
Create `geometry` collection if `STATIC_BUILD` is `true`

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -12,7 +12,7 @@ if (STATIC_BUILD && !USE_CONTENT_CACHE) {
   _.extend(collections, { ...coreDataLoader, ...galleryLoader });
 }
 
-if (PRELOAD_MAP && !USE_CONTENT_CACHE) {
+if ((PRELOAD_MAP || STATIC_BUILD) && !USE_CONTENT_CACHE) {
   _.extend(collections, geometryLoader);
 }
 


### PR DESCRIPTION
### In this PR
Resolves #750 by checking for both `STATIC_BUILD` and `PRELOAD_MAP` flags to determine whether to build the `geometry` collection.