### PR TITLE
Return no static paths on gallery page if no gallery configured

### DIFF
--- a/src/pages/[lang]/gallery/index.astro
+++ b/src/pages/[lang]/gallery/index.astro
@@ -4,7 +4,10 @@ import config from '@config';
 import Layout from '@layouts/Layout.astro';
 import _ from 'underscore';
 
-export const getStaticPaths = () => _.map(config.i18n.locales, (lang: string) => ({ params: { lang }}));
+export const getStaticPaths = () => (config.gallery
+  ? _.map(config.i18n.locales, (lang: string) => ({ params: { lang }}))
+  : []
+);
 
 ---
 


### PR DESCRIPTION
### In this PR
Resolves #734 by checking for existence of `config.gallery` in the `getStaticPaths` method on the gallery page, and returning an empty array if no gallery is configured. This fixes the problem of build errors being thrown when attempting to build the gallery page with no URL defined to fetch from.