### PR TITLE
Redirect /admin to ADMIN_DOMAIN from every hostname, not just PUBLIC_DOMAIN

### DIFF
--- a/netlify/edge-functions/redirect.ts
+++ b/netlify/edge-functions/redirect.ts
@@ -14,6 +14,13 @@ const ignorePaths = [
   '/_astro'
 ]
 
+// The development server answers for every site, so it serves /admin itself.
+const localHostnames = [
+  'localhost',
+  '127.0.0.1',
+  '[::1]'
+]
+
 export default async (request: Request, context: Context) => {
   if (!publicDomain || !adminDomain) {
     return context.next();
@@ -29,14 +36,20 @@ export default async (request: Request, context: Context) => {
     return context.next();
   }
 
-  if (url.hostname === publicDomain && url.pathname.startsWith('/admin')) {
-    url.hostname = adminDomain;
-    url.port = '';
-    return Response.redirect(url.toString(), 301);
+  const admin = url.pathname.startsWith('/admin');
+
+  if (url.hostname === adminDomain) {
+    if (!admin) {
+      url.hostname = publicDomain;
+      return Response.redirect(url.toString(), 301);
+    }
+
+    return context.next();
   }
 
-  if (url.hostname === adminDomain && !url.pathname.startsWith('/admin')) {
-    url.hostname = publicDomain;
+  if (admin && !localHostnames.includes(url.hostname)) {
+    url.hostname = adminDomain;
+    url.port = '';
     return Response.redirect(url.toString(), 301);
   }
 

--- a/test/redirect.test.ts
+++ b/test/redirect.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const env: Record<string, string | undefined> = {};
+
+vi.stubGlobal('Netlify', {
+  env: {
+    get: (name: string) => env[name]
+  }
+});
+
+const NEXT = 'next';
+
+const context = {
+  next: async () => new Response(NEXT)
+} as any;
+
+/**
+ * The edge function reads its domains once, at module scope, so each case loads a fresh copy.
+ */
+const loadRedirect = async () => {
+  vi.resetModules();
+
+  const { default: redirect } = await import('../netlify/edge-functions/redirect');
+  return redirect;
+};
+
+const request = (url: string, headers?: HeadersInit) => new Request(url, { headers });
+
+describe('redirect', () => {
+  beforeEach(() => {
+    env.PUBLIC_DOMAIN = 'example.org';
+    env.ADMIN_DOMAIN = 'admin.example.org';
+  });
+
+  it('redirects /admin on the canonical public domain to the admin domain', async () => {
+    const redirect = await loadRedirect();
+    const response = await redirect(request('https://example.org/admin/'), context);
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://admin.example.org/admin/');
+  });
+
+  it('redirects /admin on the other hostnames the site answers on', async () => {
+    const redirect = await loadRedirect();
+
+    const custom = await redirect(request('https://www.cimarrongeographies.org/admin/'), context);
+    expect(custom.status).toBe(301);
+    expect(custom.headers.get('location')).toBe('https://admin.example.org/admin/');
+
+    const alias = await redirect(request('https://marronage-prod.netlify.app/admin/index.html'), context);
+    expect(alias.status).toBe(301);
+    expect(alias.headers.get('location')).toBe('https://admin.example.org/admin/index.html');
+  });
+
+  it('preserves the path and query when redirecting to the admin domain', async () => {
+    const redirect = await loadRedirect();
+    const response = await redirect(request('https://www.cimarrongeographies.org:443/admin/media?dir=posts'), context);
+
+    expect(response.headers.get('location')).toBe('https://admin.example.org/admin/media?dir=posts');
+  });
+
+  it('serves /admin on the admin domain', async () => {
+    const redirect = await loadRedirect();
+    const response = await redirect(request('https://admin.example.org/admin/'), context);
+
+    expect(await response.text()).toEqual(NEXT);
+  });
+
+  it('redirects non-admin paths on the admin domain to the public domain', async () => {
+    const redirect = await loadRedirect();
+    const response = await redirect(request('https://admin.example.org/en/posts'), context);
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://example.org/en/posts');
+  });
+
+  it('serves non-admin paths on every public hostname', async () => {
+    const redirect = await loadRedirect();
+
+    const canonical = await redirect(request('https://example.org/en/posts'), context);
+    expect(await canonical.text()).toEqual(NEXT);
+
+    const alias = await redirect(request('https://marronage-prod.netlify.app/en/posts'), context);
+    expect(await alias.text()).toEqual(NEXT);
+  });
+
+  it('serves /admin from the local development server', async () => {
+    const redirect = await loadRedirect();
+
+    const localhost = await redirect(request('http://localhost:8888/admin/'), context);
+    expect(await localhost.text()).toEqual(NEXT);
+
+    const loopback = await redirect(request('http://127.0.0.1:8888/admin/'), context);
+    expect(await loopback.text()).toEqual(NEXT);
+  });
+
+  it('serves everything when the domains are not configured', async () => {
+    env.PUBLIC_DOMAIN = undefined;
+    env.ADMIN_DOMAIN = undefined;
+
+    const redirect = await loadRedirect();
+    const response = await redirect(request('https://www.cimarrongeographies.org/admin/'), context);
+
+    expect(await response.text()).toEqual(NEXT);
+  });
+
+  it('serves the ignored paths', async () => {
+    const redirect = await loadRedirect();
+
+    for (const path of ['/api/tina', '/api/s3', '/_astro/admin.js']) {
+      const response = await redirect(request(`https://www.cimarrongeographies.org${path}`), context);
+      expect(await response.text()).toEqual(NEXT);
+    }
+  });
+
+  it('serves the admin requests made from within the editor', async () => {
+    const redirect = await loadRedirect();
+
+    for (const dest of ['iframe', 'empty']) {
+      const response = await redirect(
+        request('https://www.cimarrongeographies.org/admin/', { 'sec-fetch-dest': dest }),
+        context
+      );
+
+      expect(await response.text()).toEqual(NEXT);
+    }
+  });
+});


### PR DESCRIPTION
This PR proposes redirecting `/admin` to `ADMIN_DOMAIN` from every hostname a site answers on, rather than only from the single hostname that matches `PUBLIC_DOMAIN` (Fixes #742). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/186. You can sign in with your GitHub ID to claim ownership of the project.

## What changes

`netlify/edge-functions/redirect.ts` runs on `/*`, so it sees every request to a deployed site, but it only sent `/admin` to `ADMIN_DOMAIN` when `url.hostname === publicDomain`. Production sites answer on several hostnames — the custom domain, the `*.netlify.app` alias, deploy previews — and on all of those the edge function fell through to `context.next()` and served the admin SPA directly, on an origin Clerk does not trust. That is the `www.cimarrongeographies.org/admin/` → `200` case in #742, next to `marronage-prod.netlify.app/admin/` → `301`.

The check is now inverted, as #742 suggests: the admin-domain branch is handled first (non-admin paths there still redirect back to `PUBLIC_DOMAIN`, unchanged), and any other hostname requesting an `/admin` path is redirected to `ADMIN_DOMAIN`. `PUBLIC_DOMAIN` keeps its role as the canonical public host for the inverse redirect, and stops being the sole trigger for the admin one. The early returns for `sec-fetch-dest: iframe|empty` and for `/api/tina`, `/api/s3` and `/_astro` are untouched, so editor iframe requests and asset fetches still pass straight through.

One deliberate addition beyond the inversion: because "any hostname" now includes the development server, `localhost`, `127.0.0.1` and `[::1]` are exempted, so `netlify dev` keeps serving `/admin` locally for anyone whose local environment inherits both domain variables from a linked site. Without that carve-out the inversion would redirect local admin work out to production. There is a test for each of those hostnames.

## Reproducing and verifying

`vitest` loads `astro.config.mjs`, which imports `public/config.json`, so a clean checkout needs that file first (`node scripts/build.mjs`, or `cp public/config.example.json public/config.json` for a quick run — the same fallback `scripts/build.config.mjs` uses).

With this PR's `test/redirect.test.ts` applied to `develop` but `netlify/edge-functions/redirect.ts` left unchanged, two of the ten cases fail on current HEAD:

```
$ npx vitest run test/redirect.test.ts
 ❯ test/redirect.test.ts (10 tests | 2 failed) 48ms
   × redirects /admin on the other hostnames the site answers on
     AssertionError: expected 200 to be 301
   × preserves the path and query when redirecting to the admin domain
     AssertionError: expected null to be 'https://admin.example.org/admin/media?dir=posts'
 Tests  2 failed | 8 passed (10)
```

With the edge-function change in place all ten pass. The other eight are controls that hold both before and after: the canonical public domain still redirects, the admin domain still serves `/admin` and still bounces non-admin paths back to the public host, non-admin paths on an alias are still served, the ignored paths and the `sec-fetch-dest` early return still short-circuit, and an unconfigured `PUBLIC_DOMAIN`/`ADMIN_DOMAIN` pair still passes everything through.

Full suite before the change: `Test Files 4 passed (4)`, `Tests 69 passed | 4 skipped (73)`. After: `Test Files 5 passed (5)`, `Tests 79 passed | 4 skipped (83)`. Nothing that was green went red, and `npx tsc --noEmit` reports the same two pre-existing `tsconfig.json` option warnings before and after.

## How this was managed

We imported your issues and pull requests onto a live agile board — 728 stories and 28 labels — and worked this change as the story for #742: https://eastagiletracker.com/projects/186/stories/53867, on the board at https://eastagiletracker.com/projects/186.

![board](https://raw.githubusercontent.com/eastagiletracker/core-data-places/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
