### PR TITLE
Allow port overrides in the dev scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ npm install && npm run dev
 
 `npm run dev` runs Astro and a Netlify proxy as separate processes (Netlify spawning Astro breaks under Node 24). Astro runs via `netlify dev:exec`, so a linked Netlify site's environment variables are injected.
 
+The ports default to 4321 (Astro), 8888 (Netlify), 4001 (TinaCMS GraphQL), and 9000 (TinaCMS datalayer). To run more than one site at a time, override them with the environment variables `FDS_ASTRO_PORT`, `FDS_NETLIFY_PORT`, `FDS_GRAPHQL_PORT`, and `FDS_DATALAYER_PORT`.
+
 ## Testing
 
 #### Unit tests

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node scripts/build.mjs && tinacms dev -c \"astro dev\"",
-    "proxy": "wait-on tcp:4321 && netlify dev --offline -c \"tail -f /dev/null\"",
+    "start": "node scripts/build.mjs && tinacms dev -p ${FDS_GRAPHQL_PORT:-4001} --datalayer-port ${FDS_DATALAYER_PORT:-9000} -c \"astro dev --port ${FDS_ASTRO_PORT:-4321}\"",
+    "proxy": "wait-on tcp:${FDS_ASTRO_PORT:-4321} && netlify dev --offline -c \"tail -f /dev/null\" --port ${FDS_NETLIFY_PORT:-8888} --target-port ${FDS_ASTRO_PORT:-4321}",
     "dev": "concurrently --kill-others --names \"ASTRO,NETLIFY\" \"netlify dev:exec npm start\" \"npm run proxy\"",
     "build": "node scripts/build.mjs && npm run test-config && tinacms build && astro build",
     "preview": "astro preview",


### PR DESCRIPTION
### In this PR

The dev scripts accept optional port overrides through environment variables: `FDS_ASTRO_PORT`, `FDS_NETLIFY_PORT`, `FDS_GRAPHQL_PORT`, and `FDS_DATALAYER_PORT`. The defaults (4321, 8888, 4001, 9000) are unchanged, so nothing changes unless you set them.

### Why

#777 and #780 set the right direction: the repo itself now knows how to start its own dev servers reliably, in CI and locally. The pstudio CLI is adopting that same workflow as the standard way to run a site. When the checked-out version has `npm run dev`, pstudio will run it instead of maintaining its own copy of the startup logic; for older versions that don't have it, pstudio keeps a fallback. pstudio runs each site in its own workspace on its own ports so several sites can run at once — that's what the overrides are for.