### PR TITLE
Change `sanitize-html` back to v2.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install && npm run dev
 
 ## Testing
 
-#### Unit tests
+#### Unit tests 
 
 ```
 npm run vitest

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install && npm run dev
 
 ## Testing
 
-#### Unit tests 
+#### Unit tests
 
 ```
 npm run vitest

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "react-dom": "^18.2.0",
         "react-instantsearch": "^7.37.0",
         "recharts": "^3.9.0",
-        "sanitize-html": "^2.17.7",
+        "sanitize-html": "^2.17.1",
         "serverless-http": "^4.0.0",
         "swiper": "^14.0.1",
         "tailwindcss": "^4.3.2",
@@ -35667,15 +35667,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/launder": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
-      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
-      "license": "MIT",
-      "dependencies": {
-        "dayjs": "^1.11.7"
-      }
-    },
     "node_modules/layout-base": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
@@ -50807,21 +50798,29 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.7",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.7.tgz",
-      "integrity": "sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.1.tgz",
+      "integrity": "sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^12.0.0",
+        "htmlparser2": "^8.0.0",
         "is-plain-object": "^5.0.0",
-        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
-      },
+      }
+    },
+    "node_modules/sanitize-html/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/sanitize-html/node_modules/escape-string-regexp": {
@@ -50834,6 +50833,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/satteri": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "react-dom": "^18.2.0",
     "react-instantsearch": "^7.37.0",
     "recharts": "^3.9.0",
-    "sanitize-html": "^2.17.7",
+    "sanitize-html": "^2.17.1",
     "serverless-http": "^4.0.0",
     "swiper": "^14.0.1",
     "tailwindcss": "^4.3.2",


### PR DESCRIPTION
### In this PR
Attempt to address issue where Netlify SSR is throwing errors when trying to load the `sanitize-html` package because of the presence of a commonJS import.

Tested in a branch deploy with the JUEL documents and the fix does seem to work: https://rb-update-sanitize-html-version--juel-staging.netlify.app/en/items/0aa3d451-f519-43cc-ac11-d5a4895ad603